### PR TITLE
Fix for python buildpack

### DIFF
--- a/scripts/builder
+++ b/scripts/builder
@@ -9,6 +9,10 @@ buildpack_root="${HOME}/build/buildpacks"
 buildpacks=($buildpack_root/*)
 selected_buildpack=
 
+# start: heroku buildpack hack (some buildpacks create "temp" /app dir)
+sudo bash -c "mkdir -p /app && chown ${STARPHLEET_APP_USER}:${STARPHLEET_APP_USER} /app"
+# end: heroku buildpack hack
+
 mkdir -p $cache_root
 mkdir -p $build_root/.profile.d
 
@@ -40,6 +44,11 @@ fi
 export REQUEST_ID=$(openssl rand -base64 32)
 
 $selected_buildpack/bin/compile "$build_root" "$cache_root"
+
+# start: heroku buildpack hack (some buildpacks create "temp" /app dir)
+sudo rm -rf "/app"
+sudo ln -s "${app_root}" "/app"
+# end: heroku buildpack hack
 
 echo "-----> Discovering process types"
 


### PR DESCRIPTION
Somewhat of a hack, but the closest I could get trying to get the ruby, python and nodejs buildpacks to all work together.

The fix is mainly for the python buildpack, which creates a temp build directory at the harcoded `/app` location and then moves the files to `${HOME}/app` when it's done.

The only solution that worked for me, was to actually create a temporary physical directory at `/app`, and then remove it after the `compile` step and redirect to `${HOME}/app` using a symbolic link instead, since some of the commands in `release` will unfortunately still reference `/app`.
