### PR TITLE
testing explicitly for the presence of an HQ remote, seems right-er

### DIFF
--- a/overlay/etc/init/starphleet_monitor_headquarters.conf
+++ b/overlay/etc/init/starphleet_monitor_headquarters.conf
@@ -5,26 +5,30 @@ stop on stopping starphleet
 
 respawn
 
-script
+pre-start script
   source `which tools`
   #initial run of ship scripts, makes sure they are run at least onces
   run_ship_scripts
-  while [ 1 ]
-  do
-    sleep "${STARPHLEET_PULSE}"
-    starphleet-public-keys
-    if [ -n "${HEADQUARTERS_REMOTE}" ]; then
-      #pull down the actual headquarters changes
-      if starphleet-git-synch "${HEADQUARTERS_REMOTE}" "${HEADQUARTERS_LOCAL}"; then
-        starphleet-buildpacks
-        starphleet-public-keys
-        starphleet-jobs "${HEADQUARTERS_LOCAL}/jobs" | sudo -u ${ADMIRAL} crontab
-      fi
-    else
-      warn "**"
-      warn You have no headquarters, add one with
-      warn starphleet-headquarters giturl
-      warn "**"
+  starphleet-public-keys
+end script
+
+script
+  source `which tools`
+  trace checking headquarters ${HEADQUARTERS_REMOTE} for updates 
+  if [ -n "${HEADQUARTERS_REMOTE}" ]; then
+    #pull down the actual headquarters changes
+    if starphleet-git-synch "${HEADQUARTERS_REMOTE}" "${HEADQUARTERS_LOCAL}"; then
+      starphleet-buildpacks
+      starphleet-public-keys
+      starphleet-jobs "${HEADQUARTERS_LOCAL}/jobs" | sudo -u ${ADMIRAL} crontab
     fi
-  done
+  else
+    warn "**"
+    warn You have no headquarters, add one with
+    warn starphleet-headquarters giturl
+    warn "**"
+  fi
+  # we'll wait a bit, and fall through allowing our respawn 
+  # to start us up again
+  sleep "${STARPHLEET_PULSE}"
 end script


### PR DESCRIPTION
This seems more like what's intended, and it is certainly more clear no?  This applies to only the first change which I, unfortunately, included in the second.
