### PR TITLE
Vagrantfile fixes for vagrant-parallels 1.1.0 (latest)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,15 +17,17 @@ Vagrant::Config.run do |config|
 end
 
 Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
-  config.vm.hostname = SHIP_NAME
+  config.vm.hostname = ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME
   config.vm.synced_folder ".", "/starphleet"
   config.vm.synced_folder "~", "/hosthome"
+  # This fixes an issue on OSX with parallels, when vagrant.pkg is still mounted
+  config.vm.synced_folder "./", "/vagrant", id: "some_id"
 
   config.vm.provider :vmware_fusion do |f, override|
     override.vm.network "public_network"
     override.vm.box = ENV['BOX_NAME'] || 'saucy-vmware'
     override.vm.box_url = "http://brennovich.s3.amazonaws.com/saucy64_vmware_fusion.box"
-    f.vmx["displayName"] = SHIP_NAME
+    f.vmx["displayName"] = ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME
     f.vmx["memsize"] = VAGRANT_MEMSIZE 
   end
 
@@ -33,14 +35,14 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
     override.vm.network "public_network"
     override.vm.box = ENV['BOX_NAME'] || 'saucy-virtualbox'
     override.vm.box_url = "https://s3.amazonaws.com/glg_starphleet/saucy-13.10-vbox-4.3.6.box"
-    f.vmx["displayName"] = SHIP_NAME
+    f.vmx["displayName"] = ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME
     f.customize ["modifyvm", :id, "--memory", VAGRANT_MEMSIZE]
   end
 
   config.vm.provider :parallels do |f, override|
     override.vm.box = ENV['BOX_NAME'] || 'saucy-parallels'
     override.vm.box_url = "https://s3.amazonaws.com/glg_starphleet/saucy-server-parallels-9-amd64-vagrant-1.4.3.box"
-    f.vmx["displayName"] = SHIP_NAME
+    f.name = ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME
     f.customize ["set", :id, "--memsize", VAGRANT_MEMSIZE]
   end
 end


### PR DESCRIPTION
I made some changed to make the VagrantFile compatible with vagrant-parallels 1.1.0.  Before that we were still on 0.2.1.
