### PR TITLE
add test to reaper for exact order name

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,6 @@ Vagrant::Config.run do |config|
   system "test -n \"${STARPHLEET_PUBLIC_KEY}\" && cp \"${STARPHLEET_PUBLIC_KEY}\" \"public_keys/\""
   system "test -n \"${STARPHLEET_HEADQUARTERS}\" && echo \"${STARPHLEET_HEADQUARTERS}\" > headquarters"
   config.vm.provision :shell, :inline => "
-  source /starphleet/overlay/etc/starphleet;
   /starphleet/scripts/starphleet-install;
   [ -n \"#{ENV['STARPHLEET_HEADQUARTERS']}\" ] && starphleet-headquarters #{ENV['STARPHLEET_HEADQUARTERS']}"
 end
@@ -26,13 +25,10 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
 
   config.vm.provider :vmware_fusion do |f, override|
     override.vm.network "public_network"
-    override.vm.box = ENV['BOX_NAME'] || 'trusty-vmware'
-    override.vm.box_url = "https://s3.amazonaws.com/glg_starphleet/trusty-14.04-amd64-vmwarefusion.box"
+    override.vm.box = ENV['BOX_NAME'] || 'saucy-vmware'
+    override.vm.box_url = "http://brennovich.s3.amazonaws.com/saucy64_vmware_fusion.box"
     f.vmx["displayName"] = ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME
     f.vmx["memsize"] = VAGRANT_MEMSIZE
-    override.vm.provision :shell, :inline => "
-      apt-get update;
-      apt-get -y upgrade;"
   end
 
   config.vm.provider :virtualbox do |f, override|


### PR DESCRIPTION
Found a problem where a deploy to trendsetter was reaping trendsetter-services as well. We added a test that accomplishes reaping the specific order containers without the collateral damage to similarly named orders eg. trendsetter-services. We spent a little extra time trying to combine lines 14 and 16 but as this is working, left as is - open to suggestions. 
