### PR TITLE
allow admiral to ssh to any container as admiral

### DIFF
--- a/scripts/starphleet-containermake
+++ b/scripts/starphleet-containermake
@@ -30,6 +30,7 @@ CONTAINER_CONF=${TMPDIR-/tmp}/${CONTAINER_NAME}.conf
 cat << EOF > ${CONTAINER_CONF}
 lxc.mount.entry = ${STARPHLEET_ROOT} ${CONTAINER_ROOT}/rootfs/${STARPHLEET_ROOT:-var/starphleet} none bind,rw 0 0
 lxc.mount.entry = ${STARPHLEET_SHARED_DATA} ${CONTAINER_ROOT}/rootfs/var/data none bind,rw 0 0
+lxc.mount.entry = ${ADMIRAL_HOME} ${CONTAINER_ROOT}/rootfs/${ADMIRAL_HOME} none defaults,bind,create=dir 0 0
 EOF
 trap 'rm -rf ${CONTAINER_CONF}' EXIT
 
@@ -78,6 +79,9 @@ else
   lxc-attach --name ${CONTAINER_NAME} -- bash -c "echo -e '\n127.0.0.1  ${CONTAINER_NAME}' >> /etc/hosts"
 
   lxc-attach --name ${CONTAINER_NAME} -- bash -c 'chmod 777 /var/log/'
+  lxc-attach --name ${CONTAINER_NAME} -- bash -c 'useradd -s /bin/bash ${ADMIRAL} || true'
+  lxc-attach --name ${CONTAINER_NAME} -- bash -c 'adduser ${ADMIRAL} sudo'
+  lxc-attach --name ${CONTAINER_NAME} -- bash -c 'chown -R ${ADMIRAL}:${ADMIRAL} ${ADMIRAL_HOME}/.ssh'
   lxc-attach --name ${CONTAINER_NAME} -- bash -c 'echo -e "\n${STARPHLEET_APP_USER} ALL=NOPASSWD:ALL" >> /etc/sudoers'
   lxc-attach --name ${CONTAINER_NAME} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "source /usr/bin/tools; /build_script"
   if [ "${run}" == "true" ]; then

--- a/scripts/starphleet-containermake
+++ b/scripts/starphleet-containermake
@@ -82,6 +82,7 @@ else
   lxc-attach --name ${CONTAINER_NAME} -- bash -c 'useradd -s /bin/bash ${ADMIRAL} || true'
   lxc-attach --name ${CONTAINER_NAME} -- bash -c 'adduser ${ADMIRAL} sudo'
   lxc-attach --name ${CONTAINER_NAME} -- bash -c 'chown -R ${ADMIRAL}:${ADMIRAL} ${ADMIRAL_HOME}/.ssh'
+  lxc-attach --name ${CONTAINER_NAME} -- bash -c 'echo -e "\n${ADMIRAL} ALL=NOPASSWD:ALL" >> /etc/sudoers'
   lxc-attach --name ${CONTAINER_NAME} -- bash -c 'echo -e "\n${STARPHLEET_APP_USER} ALL=NOPASSWD:ALL" >> /etc/sudoers'
   lxc-attach --name ${CONTAINER_NAME} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "source /usr/bin/tools; /build_script"
   if [ "${run}" == "true" ]; then

--- a/scripts/starphleet-lxc-ssh
+++ b/scripts/starphleet-lxc-ssh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+### Usage:
+###    starphleet-lxc-ssh ORDERNAME [COMMAND ...]
+### --help
+###
+###   "Runs ssh to connect to the given container"
+###   
+###   "Arguments:"
+###   "NAME    : name of the original starphleet order.  Replaced with the IP address of the container."
+###   "COMMAND : optional command to pass to ssh"
+###
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source ${DIR}/tools
+help=$(grep "^### " "$0" | cut -c 5-)
+eval "$(${DIR}/docopts -h "$help" -V "$version" : "$@")"
+trace "$(basename "$(test -L "$0" && readlink "$0" || echo "$0")") : $*"
+set -e
+
+get_ip()
+{
+    # Get init's PID
+    PID=$(sudo lxc-info -n ${FULL_LXCNAME} -p | awk '{print $2}')
+    [ "$PID" = "-1" ] && return 1
+
+    # Get some unique path
+    DST=$(sudo mktemp -u --tmpdir=/run/netns/)
+    NAME=$(basename $DST)
+
+    # Prepare the /run/netns entry for "ip netns"
+    sudo mkdir -p /run/netns
+    sudo ln -s /proc/$PID/ns/net $DST
+
+    # Grab all the public globally routed IPv4 and IPv6 addresses
+    (sudo ip netns exec $NAME ip -4 addr show scope global && \
+     sudo ip netns exec $NAME ip -6 addr show scope global) | grep inet | while read line; do
+        ip=$(echo $line | awk '{print $2}' | cut -d '/' -f1)
+        echo "$ip"
+    done
+
+    sudo rm $DST
+}
+
+get_full_lxcname()
+{
+  for name in $(sudo lxc-ls | grep --extended-regexp "service-${ENCODED_ORDER}-([a-f0-9]){7}-([a-f0-9]){7}")
+  do
+    echo "$name"
+  done
+
+}
+
+do_ssh()
+{
+    
+    FULL_LXCNAME=$(get_full_lxcname $ENCODED_ORDER)
+    sudo lxc-wait -s RUNNING -n $FULL_LXCNAME
+
+    # Use get_ip to wait for container's network to be up
+    # and to obtain the ip address, then we can ssh to the lxc.
+    TRIES=60
+    FAILED=1
+
+    # Repeatedly try to connect over SSH until we either succeed
+    # or time out.
+    for i in $(seq 1 $TRIES); do
+        # We call get_ip inside the loop to ensure the correct ip
+        # is retrieved even in the case the DHCP ip assignment
+        # changes during the process.
+        IP_ADDRESS=$(get_ip $FULL_LXCNAME)
+        if [ -z "$IP_ADDRESS" ]; then
+            sleep 1
+            continue
+        fi
+
+        # Iterate through all the addresses (if multiple)
+        for ip in $IP_ADDRESS; do
+            ssh -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null \
+                $SSH_OPTS \
+                admiral@$IP_ADDRESS "$@"
+            if [ ! 255 -eq $? ]; then
+                # If ssh returns 255 then its connection failed.
+                # Anything else is either success (status 0) or a
+                # failure from whatever we ran over the SSH connection.
+                # In those cases we want to stop looping, so we break
+                # here
+
+                FAILED=0
+                break;
+            fi
+        done
+
+        if [ "$FAILED" = "0" ]; then
+            break
+        fi
+        sleep 1
+    done
+
+    if [ "$FAILED" = "1" ]; then
+        echo "could not get IP address - aborting." >&2
+    fi
+}
+
+ENCODED_ORDER=$(urlencode "$1")
+shift
+SSH_OPTS="-t"
+do_ssh "$@"

--- a/scripts/starphleet-lxc-ssh
+++ b/scripts/starphleet-lxc-ssh
@@ -16,45 +16,19 @@ eval "$(${DIR}/docopts -h "$help" -V "$version" : "$@")"
 trace "$(basename "$(test -L "$0" && readlink "$0" || echo "$0")") : $*"
 set -e
 
-get_ip()
-{
-    # Get init's PID
-    PID=$(sudo lxc-info -n ${FULL_LXCNAME} -p | awk '{print $2}')
-    [ "$PID" = "-1" ] && return 1
-
-    # Get some unique path
-    DST=$(sudo mktemp -u --tmpdir=/run/netns/)
-    NAME=$(basename $DST)
-
-    # Prepare the /run/netns entry for "ip netns"
-    sudo mkdir -p /run/netns
-    sudo ln -s /proc/$PID/ns/net $DST
-
-    # Grab all the public globally routed IPv4 and IPv6 addresses
-    (sudo ip netns exec $NAME ip -4 addr show scope global && \
-     sudo ip netns exec $NAME ip -6 addr show scope global) | grep inet | while read line; do
-        ip=$(echo $line | awk '{print $2}' | cut -d '/' -f1)
+get_ip(){
+  for name in $(sudo lxc-ls --running | grep --extended-regexp "service-${ENCODED_ORDER}-([a-f0-9]){7}-([a-f0-9]){7}")
+    do
+      ip=$(sudo lxc-ls --fancy -F ipv4 $name | tail -1)
+      if [ -n  ${ip} ]; then
         echo "$ip"
-    done
-
-    sudo rm $DST
-}
-
-get_full_lxcname()
-{
-  for name in $(sudo lxc-ls | grep --extended-regexp "service-${ENCODED_ORDER}-([a-f0-9]){7}-([a-f0-9]){7}")
-  do
-    echo "$name"
+        break;
+      fi
   done
-
 }
 
-do_ssh()
-{
+do_ssh(){
     
-    FULL_LXCNAME=$(get_full_lxcname $ENCODED_ORDER)
-    sudo lxc-wait -s RUNNING -n $FULL_LXCNAME
-
     # Use get_ip to wait for container's network to be up
     # and to obtain the ip address, then we can ssh to the lxc.
     TRIES=60
@@ -63,10 +37,7 @@ do_ssh()
     # Repeatedly try to connect over SSH until we either succeed
     # or time out.
     for i in $(seq 1 $TRIES); do
-        # We call get_ip inside the loop to ensure the correct ip
-        # is retrieved even in the case the DHCP ip assignment
-        # changes during the process.
-        IP_ADDRESS=$(get_ip $FULL_LXCNAME)
+        IP_ADDRESS=$(get_ip $ENCODED_ORDER)
         if [ -z "$IP_ADDRESS" ]; then
             sleep 1
             continue

--- a/scripts/starphleet-public-keys
+++ b/scripts/starphleet-public-keys
@@ -30,6 +30,7 @@ do
     echo '' >> ${AUTHFILE}
   fi
 done
+cat "${ADMIRALSSH}/id_rsa.pub" >> ${AUTHFILE}
 
 chmod 600 ${AUTHFILE}
 chown ${ADMIRAL}:${ADMIRAL} ${AUTHFILE}

--- a/scripts/tools
+++ b/scripts/tools
@@ -74,7 +74,7 @@ function make_admiral() {
   adduser ${ADMIRAL} sudo
   adduser ${ADMIRAL} adm
   adduser ${ADMIRAL} root
-  test -d ${ADMIRAL_HOME}/.ssh || mkdir -p ${ADMIRAL_HOME}/.ssh
+  test -d ${ADMIRAL_HOME}/.ssh || mkdir -p ${ADMIRAL_HOME}/.ssh; ssh-keygen -t rsa -f "${ADMIRAL_HOME}/.ssh/id_rsa" -q -N "" -C 'admiral of the phleet'
   mkdir -p ${STARPHLEET_ROOT}
   chown -R ${ADMIRAL}:${ADMIRAL} ${STARPHLEET_ROOT}
   chown -R ${ADMIRAL}:${ADMIRAL} ${ADMIRAL_HOME}


### PR DESCRIPTION
starphleet-lxc-ssh is a new file that takes as arguments an order name and optional a command to run on the container.
 
starphleet-containermake changes are to mount the ships /home/admiral and create just the folder /home/admiral on the new container. Also, on the new container we add the admiral user since the containder will not have a uid for admiral when we chown the folder. 

In tools we create a private/public key that we then cat to the auth file.