### PR TITLE
we really want our 'slashless redirect' to happen only when we have an e...

### DIFF
--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -50,7 +50,7 @@ test ! -d "${NGINX_CONF}/published_bare" && mkdir -p "${NGINX_CONF}/published_ba
 #redirect to forgive a lack of trailing slash
 if [ -n "${public_url}" ]; then
 cat << EOF >> "${MOUNT_CONF}"
-location ~* ${public_url}$ {
+location = ${public_url} {
   rewrite .* ${public_url}/ last;
 }
 EOF


### PR DESCRIPTION
Turns out we have a location redirect that is using a regular expression, when I _think_ we want an exact match.  As it stands before this change this:

 http://jobs.glgresearch.com/cerca/surveys_023aedd41_2014-10-22/_alias/surveys

matches the surveys service, which is clearly undesirable as the URL is trying to get at cerca.  My thought is that we, no foolin, want to redirect the exact match of /<service_name> to /<service_name>/ so the exact match '=' is fine.  Also, since the original /<service_name>/ location is not case insensitive, there's no need for that portion of the existing regex either.

That's all assuming I read the docs correctly.
