### PR TITLE
Prevent NGINX From locking up due to LDAP

### DIFF
--- a/nginx/nginx-auth-ldap/ngx_http_auth_ldap_module.c
+++ b/nginx/nginx-auth-ldap/ngx_http_auth_ldap_module.c
@@ -1002,6 +1002,7 @@ ngx_http_auth_ldap_close_connection(ngx_http_auth_ldap_connection_t *c)
         //         Otherwise, this is most likely a leak
         counter++;
         if (counter > 1000) {
+          ngx_log_error(NGX_LOG_INFO, c->log, 0, "http_auth_ldap: GLG Hack - Punted on LDAP Disconnect");
           break;
         }
     }


### PR DESCRIPTION
This tweak has been tested on Asia and Europe.  I have not observed any adverse side effects.  I have observed the event that locks up NGINX triggering this tweak several times and this tweak has prevented NGINX from locking up thus far.

I do not know enough about the depths of what is happening inside NGINX to understand why the connection pool is losing a reference to the connection this code expects, but after 1000 iterations this is most certainly poked at all of them and beyond the point at which it will find whatever it's looking for.

I have submitted a bug with the author of the ldap_auth module for NGINX and suggest we upgrade to their fix if they ever respond.  In the meantime, this seems to help alleviate the issue on our starphleet systems.
