### PR TITLE
Stricter regex matching for service names

### DIFF
--- a/scripts/starphleet-lxc-destroy
+++ b/scripts/starphleet-lxc-destroy
@@ -13,7 +13,7 @@ eval "$(${DIR}/docopts -h "$help" -V "$version" : "$@")"
 
 starphleet-lxc-stop "${container_name}"
 
-while lxc-ls | grep "^${container_name}"; do
+while lxc-ls | grep "^${container_name}$"; do
   info destroying ${container_name}
   lxc-destroy --name "${container_name}" 2>&1
   sleep 1

--- a/scripts/starphleet-lxc-stop
+++ b/scripts/starphleet-lxc-stop
@@ -8,7 +8,7 @@ source ${DIR}/tools
 help=$(grep "^### " "$0" | cut -c 5-)
 eval "$(${DIR}/docopts -h "$help" -V "$version" : "$@")"
 
-while lxc-ls --running | grep "^${container_name}"; do
+while lxc-ls --running | grep "^${container_name}$"; do
   info stopping ${container_name}
   lxc-stop --name ${container_name} 2>&1
   sleep 1

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -31,7 +31,7 @@ BETA_CONF="${NGINX_CONF}/published/$(urlencode \"${public_url}\").beta"
 #redirect your urls to lxc
 REDIRECT_CONF="${NGINX_CONF}/published/$(urlencode \"${public_url}\").redirect"
 
-IP_ADDRESS=$(lxc-ls --fancy | grep "^${container_name}" | awk '{ print $3; }')
+IP_ADDRESS=$(lxc-ls --fancy | grep "^${container_name}[[:space:]]" | awk '{ print $3; }')
 
 info publishing to ${IP_ADDRESS}
 

--- a/scripts/starphleet-ready
+++ b/scripts/starphleet-ready
@@ -12,7 +12,7 @@ trace "$(basename "$(test -L "$0" && readlink "$0" || echo "$0")") : $*"
 
 PORT=${container_port:-${PORT}}
 URL=${url:-/}
-IP_ADDRESS=$(lxc-ls --fancy | grep "^${container_name}" | awk '{ print $3; }')
+IP_ADDRESS=$(lxc-ls --fancy | grep "^${container_name}[[:space:]]" | awk '{ print $3; }')
 
 TEST_PASSED=false
 for c in {1..180}; do


### PR DESCRIPTION
Fixes cerca & cerca-indexer bad regex matching and subsequent destruction of healthy services
