### PR TITLE
Bug Fix - "Unpublished" Orders Grabbing Wrong Git Repo

### DIFF
--- a/scripts/tools
+++ b/scripts/tools
@@ -113,7 +113,10 @@ function run_orders()
     STOP_BEFORE_AUTODEPLOY=1
   }
 
+  # If the order is unpublished - push an 'empty' link to ${AUTODEPLOY} so the previous
+  # git repo doesn't accidently get re-copied into the wrong order file
   unpublished () {
+    [ -n "${AUTODEPLOY}" ] && echo "" > "${AUTODEPLOY}";
     UNPUBLISHED=1
   }
 

--- a/scripts/tools
+++ b/scripts/tools
@@ -114,7 +114,7 @@ function run_orders()
   }
 
   # If the order is unpublished - push an 'empty' link to ${AUTODEPLOY} so the previous
-  # git repo doesn't accidently get re-copied into the wrong order file
+  # git repo doesn't accidently get re-copied into the wrong order folder
   unpublished () {
     [ -n "${AUTODEPLOY}" ] && echo "" > "${AUTODEPLOY}";
     UNPUBLISHED=1


### PR DESCRIPTION
- BUG: If an order is unpublished it is currently still grabbing the GIT repo
  from the previous order that is processed by starphleet_monitor_orders.
  This occurs because the run_orders function in 'tools' echos the git
  repo into /tmp/$$ [pid] for autodeploys but does not clear out this file
  if the order is unpublished.  Thus, the next few lines of code in starphleet_monitor_orders 
  still detect a ${REMOTE} and grabs the git repo from the previous processed autodeploy.
- FIX: This change clears out the /tmp/$$ for unpublished order files.  I think
  this should prevent unpublished orders from grabbing the wrong
  GIT repo