### PR TITLE
ldap work around for other containers on the ship

### DIFF
--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -99,9 +99,7 @@ if [[ "${ldap}" != '' && "${ldap}" != '-' ]]; then
   # see http://forum.nginx.org/read.php?2,242713,242742#msg-242742
   # note: this needs an auth_basic that alway fails and has the same name as auth_ldap
   echo "  satisfy any;" >> "${MOUNT_CONF}"
-  echo "  auth_basic \"Forbidden!\";" >> "${MOUNT_CONF}"
   echo "  allow 10.0.3.0/8;" >> "${MOUNT_CONF}"
-  echo "  deny all;" >> "${MOUNT_CONF}"
 fi
 
 echo "" > "${BETA_CONF}"

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -94,6 +94,14 @@ if [[ "${ldap}" != '' && "${ldap}" != '-' ]]; then
   echo "  auth_ldap_servers $(cat ${ldap});" >> "${MOUNT_CONF}"
   echo "  proxy_set_header ${USER_IDENTITY_HEADER} \$remote_user;" >> "${MOUNT_CONF}"
   echo "  add_header Set-Cookie ${USER_IDENTITY_COOKIE}=\$remote_user;" >> "${MOUNT_CONF}"
+
+  # don't want to ldap authenticate from other containers on the ship
+  # see http://forum.nginx.org/read.php?2,242713,242742#msg-242742
+  # note: this needs an auth_basic that alway fails and has the same name as auth_ldap
+  echo "  satisfy any;" >> "${MOUNT_CONF}"
+  echo "  auth_basic \"Forbidden!\";" >> "${MOUNT_CONF}"
+  echo "  allow 10.0.3.0/8;" >> "${MOUNT_CONF}"
+  echo "  deny all;" >> "${MOUNT_CONF}"
 fi
 
 echo "" > "${BETA_CONF}"


### PR DESCRIPTION
allows one of my services to call http://localship/foo w/o authenticating, but requests from outside the 10.0.3.x network still need to go through ldap
