### PR TITLE
Bug: Make rewrite rules be tied to root path

### DIFF
--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -106,10 +106,10 @@ echo "" > "${BETA_CONF}"
 for beta in "${!BETAS[@]}"
 do
   echo "  if (\$starphleet_beta_${beta}) {" >> "${BETA_CONF}"
-  echo "    rewrite ${public_url}/(.*) ${BETAS[$beta]}/\$1 last;" >> "${BETA_CONF}"
+  echo "    rewrite ^${public_url}/(.*) ${BETAS[$beta]}/\$1 last;" >> "${BETA_CONF}"
   echo "  }" >> "${BETA_CONF}"
   echo "  if (\$starphleet_beta_${beta}_cookie) {" >> "${BETA_CONF}"
-  echo "    rewrite ${public_url}/(.*) ${BETAS[$beta]}/\$1 last;" >> "${BETA_CONF}"
+  echo "    rewrite ^${public_url}/(.*) ${BETAS[$beta]}/\$1 last;" >> "${BETA_CONF}"
   echo "  }" >> "${BETA_CONF}"
 done
 


### PR DESCRIPTION
This bug was manifested by the beta rewrite rules.  In a case where you were in a beta for the following service/endpoint things work fine:

    *.domain.com/someservice/endpoint

However, the rewrite rules for the above beta group would also match:

    *.domain.com/someotherservice/someservice/endpoint

This will 'break' the above url for anything pointing to _url_/someservice/_endpoint_.  The below should anchor the rewrite rules for a beta to the service they are intended.