### PR TITLE
Use ship name in all syslog entries

### DIFF
--- a/overlay/etc/rsyslog.conf
+++ b/overlay/etc/rsyslog.conf
@@ -28,10 +28,11 @@ $UDPServerRun 514
 ###########################
 
 #
-# Use traditional timestamp format.
-# To enable high precision timestamps, comment out the following line.
+# Use traditional timestamp format
+# Using custom hostname to enforce ship as permanent host
 #
-$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+$template PhleetFileFormat, "%TIMESTAMP% %$myhostname% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n
+$ActionFileDefaultTemplate PhleetFileFormat
 
 # Filter duplicated messages
 $RepeatedMsgReduction on

--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -39,6 +39,9 @@ hostname "${SHIP}"
 echo "${SHIP}" > /etc/hostname
 echo "127.0.0.1 ${SHIP} localhost" > /etc/hosts
 
+# restart rsyslog for it to pick up new hostname
+service rsyslog restart
+
 #packages
 debconf-set-selections <<< "postfix postfix/mailname string '${SHIP}'"
 debconf-set-selections <<< "postfix postfix/main_mailer_type string 'Internet Site'"


### PR DESCRIPTION
Using the default RSYSLOG_TraditionalFileFormat added %HOSTNAME% to syslog messages. If the log came from a container, the hostname was the ip of the container. In these cases, the log had no mention of the ship name. Losing that ip is fine because we already have the name of the service in the log message.