### PR TITLE
Bug - starphleet-redeploy does not trigger deploy for unpublished orders

### DIFF
--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -106,10 +106,10 @@ echo "" > "${BETA_CONF}"
 for beta in "${!BETAS[@]}"
 do
   echo "  if (\$starphleet_beta_${beta}) {" >> "${BETA_CONF}"
-  echo "    rewrite ${public_url}/(.*) ${BETAS[$beta]}/\$1 last;" >> "${BETA_CONF}"
+  echo "    rewrite ^${public_url}/(.*) ${BETAS[$beta]}/\$1 last;" >> "${BETA_CONF}"
   echo "  }" >> "${BETA_CONF}"
   echo "  if (\$starphleet_beta_${beta}_cookie) {" >> "${BETA_CONF}"
-  echo "    rewrite ${public_url}/(.*) ${BETAS[$beta]}/\$1 last;" >> "${BETA_CONF}"
+  echo "    rewrite ^${public_url}/(.*) ${BETAS[$beta]}/\$1 last;" >> "${BETA_CONF}"
   echo "  }" >> "${BETA_CONF}"
 done
 

--- a/scripts/starphleet-redeploy
+++ b/scripts/starphleet-redeploy
@@ -9,5 +9,7 @@ run_as_root_or_die
 
 rm -rf ${HEADQUARTERS_LOCAL}/${order}/git
 rm -rf ${CURRENT_ORDERS}/${order}/git
+# Force a redeploy of unpublished orders which don't include GIT repos
+rm "${CURRENT_ORDERS}/${order}/.orders_sha"
 echo 'building' > "${CURRENT_ORDERS}/${order}/.starphleetstatus"
 starphleet-reaper zzzzzzzzz "${order}"


### PR DESCRIPTION
Since unpublished orders do not have a git repo - only removing the non-existent repos does not trigger a redeploy of unpublished orders.

Removing the ".orders_sha" does cause an "unpublished" to redeploy.
