### PR TITLE
Also save the port the service was exported on

### DIFF
--- a/overlay/etc/init/starphleet_serve_order.conf
+++ b/overlay/etc/init/starphleet_serve_order.conf
@@ -109,6 +109,7 @@ post-start script
       echo 'online' > "${CURRENT_ORDERS}/${order}/.starphleetstatus"
       echo "${name}" > "${CURRENT_ORDERS}/${order}/.last_known_good_container"
       lxc-ls --fancy "${name}" | tail -1 | awk '{ print $3; }' > "${CURRENT_ORDERS}/${order}/.starphleetstatus.ip"
+      echo "${PORT}" > "${CURRENT_ORDERS}/${order}/.starphleetstatus.port"
       #any prior version of this order should now be reaped after
       #we wait a small time for prior requests to flush out
       sleep ${STARPHLEET_DRAINSTOP_WAIT}


### PR DESCRIPTION
I'd like to hook up a healthcheck $thing.  The healthcheck may run within a container.  

When querying the orders files for healthchecks, I'd like to then run that healthcheck directly against the containers IP address.  I'm going to get that ip from .starphleetstatus.ip and would like the port as well.