### PR TITLE
Headquarters var doesn't get set in this context so set it

### DIFF
--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -15,6 +15,8 @@ eval "$(${DIR}/docopts -h "$help" -V "$version" : "$@")"
 trace "$(basename "$(test -L "$0" && readlink "$0" || echo "$0")") : $*"
 set -e
 
+STARPHLEET_HEADQUARTERS=${STARPHLEET_HEADQUARTERS:-/var/starphleet/headquarters}
+
 declare -A BETAS
 run_orders "${orders}"
 


### PR DESCRIPTION
My commit got slurped before this was added.  Turns out ${STARPHLEET_HEADQUARTERS} isn't available in publish so:

I respect if set.. but put in a default if not set.

