### PR TITLE
Only list DNAT rules

### DIFF
--- a/scripts/starphleet-expose
+++ b/scripts/starphleet-expose
@@ -21,7 +21,7 @@ function expose() {
     error "Sorry, I won't let you mess up NGINX"
   else
     info "expose ${container_name} on ${1}"
-    for i in $( iptables -t nat --line-numbers -L | grep ^[0-9] | grep ${1} | awk '{ print $1 }' | tac ); do iptables -t nat -D PREROUTING $i; done
+    for i in $( iptables -t nat --line-numbers -L | grep ^[0-9] | grep DNAT | grep ${1} | awk '{ print $1 }' | tac ); do iptables -t nat -D PREROUTING $i; done
     iptables -t nat -I PREROUTING -p tcp -i eth0 --dport ${1} -j DNAT --to ${IP_ADDRESS}:${1}
   fi
 }


### PR DESCRIPTION
If someone were to accidentally expose port '10' this would accidentally match the MASQ rule assigned to the 10.0.3.* subnet.  The iptables command that purges PREROUTING rules will only run against the 'PREROUTING' table but would cause an error on a rule number that doesn't exist in that table.  By grepping for only DNAT rules we can avoid this accident. 