### PR TITLE
Attach as "ubuntu" user

### DIFF
--- a/scripts/starphleet-attach
+++ b/scripts/starphleet-attach
@@ -16,6 +16,6 @@ CONTAINERS=$(lxc-ls -f | grep RUNNING | grep ${service} | awk '{print $1}')
 # Now figure out which container they want and attach
 echo "Connect to which instance:"
 select container in $(lxc-ls -f | grep RUNNING | grep ${service} | awk '{print $1}'); do
-  [ ! -z ${container} ] && sudo lxc-attach -n "${container}"
+  [ ! -z ${container} ] && sudo lxc-attach -n "${container}" -- su - ubuntu
   break;
 done


### PR DESCRIPTION
- When using 'starphleet-attach' I conjecture most of the time we want
  to be logged in as the user in which apps run.  Pass the command
  "su - ubuntu" into the attach to simulate a login as 'ubuntu'