### PR TITLE
add apt-get update/upgrade to install script so it works locally

### DIFF
--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -42,6 +42,8 @@ echo "127.0.0.1 ${SHIP} localhost" > /etc/hosts
 #packages
 debconf-set-selections <<< "postfix postfix/mailname string '${SHIP}'"
 debconf-set-selections <<< "postfix postfix/main_mailer_type string 'Internet Site'"
+apt-get update
+apt-get upgrade
 apt-get -y install --force-yes software-properties-common
 
 # Run Upgrade before before installing packages - which fixes this error


### PR DESCRIPTION
Local vagrant install won't work unless apt-get update and apt-get upgrade are run before the initial apt-get installs.