### PR TITLE
Pass the service name (order) through

### DIFF
--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -68,12 +68,12 @@ location ${public_url}/ {
   proxy_set_header X-Forwarded-Host \$host;
   proxy_set_header X-Forwarded-Server \$host;
   proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+  proxy_set_header X-Starphleet-Service-Name: ${order};
   proxy_set_header Host \$http_host;
   # WebSocket support (nginx 1.4)
   proxy_http_version 1.1;
   proxy_set_header Upgrade \$http_upgrade;
   proxy_set_header Connection "upgrade";
-  more_set_headers 'X-Starphleet-Service-Name: ${order}';
   more_set_headers 'X-Starphleet-Service: ${public_url}';
   more_set_headers 'X-Starphleet-Container: ${container_name}';
 EOF


### PR DESCRIPTION
- Give the container the service name
- Previous commit only announced the container name but we want it to make it into the container