### PR TITLE
Install Starphleet on EC2 and auto deploy disks:

### DIFF
--- a/overlay/etc/logrotate.d/rsyslog
+++ b/overlay/etc/logrotate.d/rsyslog
@@ -11,7 +11,7 @@
         endscript
 }
 
-/var/log/biglogs/*
+/var/log/biglogs/syslog
 {
         rotate 1
         missingok

--- a/overlay/etc/logrotate.d/rsyslog
+++ b/overlay/etc/logrotate.d/rsyslog
@@ -11,6 +11,19 @@
         endscript
 }
 
+/var/log/biglogs/*
+{
+        rotate 1
+        missingok
+        notifempty
+        delaycompress
+        compress
+        size 100M
+        postrotate
+                reload rsyslog >/dev/null 2>&1 || true
+        endscript
+}
+
 /var/log/mail.info
 /var/log/mail.warn
 /var/log/mail.err

--- a/overlay/etc/starphleet
+++ b/overlay/etc/starphleet
@@ -39,4 +39,4 @@ export NGINX_STATUS_ENDPOINT_CONFIG="/var/starphleet/nginx/status.conf"
 declare -A EC2_DRIVES
 EC2_DRIVES["/dev/xvdb"]="/var/lib/lxc"
 EC2_DRIVES["/dev/xvdc"]="/var/starphleet"
-EC2_DRIVES["/dev/xvdd"]="/var/log"
+EC2_DRIVES["/dev/xvdd"]="/var/log/biglogs"

--- a/overlay/etc/starphleet
+++ b/overlay/etc/starphleet
@@ -35,3 +35,8 @@ export USER_IDENTITY_COOKIE="starphleet_user"
 export NGINX_PUBLISHED_PATH="/var/starphleet/nginx/published"
 export NGINX_STATUS_CONFIG_SYMLINK="${NGINX_PUBLISHED_PATH}/starphleet_nginx_status.status"
 export NGINX_STATUS_ENDPOINT_CONFIG="/var/starphleet/nginx/status.conf"
+# Declare drives we'd setup and where they should mount for starphleet install on EC2
+declare -A EC2_DRIVES
+EC2_DRIVES["/dev/xvdb"]="/var/lib/lxc"
+EC2_DRIVES["/dev/xvdc"]="/var/starphleet"
+EC2_DRIVES["/dev/xvdd"]="/var/log"

--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -11,6 +11,12 @@ eval "$(${DIR}/docopts -h "$help" -V "$version" : "$@")"
 trace "$(basename "$(test -L "$0" && readlink "$0" || echo "$0")") : $*"
 set -e
 
+# ******************
+# TODO: Figure out how they want to handle this on a fresh install
+# ******************
+export DIR=${DIR}
+export SCRIPT_DIR=${DIR}
+
 run_as_root_or_die
 
 #flush out caches, I know, I know -- but really if you don't do this

--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -4,21 +4,6 @@
 ### --help
 ###
 ### This will get starphleet on a base machine
-# ******************
-# TODO: Fresh install doesn't have starphleet-launcher yet
-# ******************
-# DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-# source ${DIR}/tools
-# help=$(grep "^### " "$0" | cut -c 5-)
-# eval "$(${DIR}/docopts -h "$help" -V "$version" : "$@")"
-# trace "$(basename "$(test -L "$0" && readlink "$0" || echo "$0")") : $*"
-# set -e
-
-# ******************
-# TODO: Figure out how they want to handle this
-# ******************
-# export DIR=${DIR}
-# export SCRIPT_DIR=${DIR}
 
 run_as_root_or_die
 

--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -59,8 +59,8 @@ echo "127.0.0.1 ${SHIP} localhost" > /etc/hosts
 #packages
 debconf-set-selections <<< "postfix postfix/mailname string '${SHIP}'"
 debconf-set-selections <<< "postfix postfix/main_mailer_type string 'Internet Site'"
-apt-get update
-apt-get upgrade
+apt-get update -y
+apt-get upgrade -y
 apt-get -y install --force-yes software-properties-common
 
 # Run Upgrade before before installing packages - which fixes this error

--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -112,10 +112,6 @@ ${DIR}/starphleet-build-base-container
 
 starphleet-cleanup
 
-# In case we mounted a new file system at /var/log during install we
-# restart syslog
-# TODO: Might be safer to reboot
-restart rsyslog
 # Start starphleet
 start starphleet
 announce *Welcome to Starphleet*

--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -60,12 +60,10 @@ echo "127.0.0.1 ${SHIP} localhost" > /etc/hosts
 debconf-set-selections <<< "postfix postfix/mailname string '${SHIP}'"
 debconf-set-selections <<< "postfix postfix/main_mailer_type string 'Internet Site'"
 apt-get update -y
-apt-get upgrade -y
-apt-get -y install --force-yes software-properties-common
-
 # Run Upgrade before before installing packages - which fixes this error
 # https://github.com/lxc/lxc/issues/247
 export DEBIAN_FRONTEND=noninteractive; apt-get dist-upgrade -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --force-yes
+apt-get -y install --force-yes software-properties-common
 
 apt-get -y install --force-yes $(< "${DIR}/packages")
 

--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env starphleet-launcher
 ### Usage:
 ###    starphleet-install
 ### --help
@@ -7,18 +7,18 @@
 # ******************
 # TODO: Fresh install doesn't have starphleet-launcher yet
 # ******************
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source ${DIR}/tools
-help=$(grep "^### " "$0" | cut -c 5-)
-eval "$(${DIR}/docopts -h "$help" -V "$version" : "$@")"
-trace "$(basename "$(test -L "$0" && readlink "$0" || echo "$0")") : $*"
-set -e
+# DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# source ${DIR}/tools
+# help=$(grep "^### " "$0" | cut -c 5-)
+# eval "$(${DIR}/docopts -h "$help" -V "$version" : "$@")"
+# trace "$(basename "$(test -L "$0" && readlink "$0" || echo "$0")") : $*"
+# set -e
 
 # ******************
 # TODO: Figure out how they want to handle this
 # ******************
-export DIR=${DIR}
-export SCRIPT_DIR=${DIR}
+# export DIR=${DIR}
+# export SCRIPT_DIR=${DIR}
 
 run_as_root_or_die
 

--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -91,7 +91,7 @@ root	ALL=(ALL:ALL) ALL
 %admin ALL=(ALL) ALL
 %sudo	ALL=(ALL:ALL) NOPASSWD:ALL
 vagrant ALL=NOPASSWD: ALL
-Defaults env_keep="sSH_AUTH_SOCK"
+Defaults env_keep="SSH_AUTH_SOCK"
 Defaults !requiretty
 EOF
 

--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -1,9 +1,15 @@
-#!/usr/bin/env starphleet-launcher
+#!/usr/bin/env bash
 ### Usage:
 ###    starphleet-install
 ### --help
 ###
 ### This will get starphleet on a base machine
+
+# On a fresh install starphleet-launcher doesn't exist for /usr/bin/env
+# so hopefully they are running this in the scripts dir
+[ -f ./starphleet-launcher ] && cp ./starphleet-launcher /usr/bin
+[ -f /usr/bin/starphleet-launcher ] && source /usr/bin/starphleet-launcher
+
 run_as_root_or_die
 
 

--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -12,14 +12,15 @@ run_as_root_or_die
 sync && echo 3 > /proc/sys/vm/drop_caches
 
 # To support a fresh installation but keep the config in the overlay
-# we need access to the default starphleet config.  Any overrides
-# will happen after perform-overlay and re-slurpage of tools
+# we need access to the default starphleet config. We are going
+# to attempt to slurp it in
 #
-# We declare it in case overlay fails
+# We declare EC2_DRIVES in case we can't find the overlay config
 declare -A EC2_DRIVES
 # Then try to get the defaults from the starphleet config
 [ -f ../overlay/etc/starphleet ] && source ../overlay/etc/starphleet
 
+# Auto handle formatting/mounting of EC2 Drives
 ec2_mounts
 
 #put in the system overlay, gets all the files in place

--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -4,11 +4,12 @@
 ### --help
 ###
 ### This will get starphleet on a base machine
-
-# On a fresh install starphleet-launcher doesn't exist for /usr/bin/env
-# so hopefully they are running this in the scripts dir
-[ -f ./starphleet-launcher ] && cp ./starphleet-launcher /usr/bin
-[ -f /usr/bin/starphleet-launcher ] && source /usr/bin/starphleet-launcher
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source ${DIR}/tools
+help=$(grep "^### " "$0" | cut -c 5-)
+eval "$(${DIR}/docopts -h "$help" -V "$version" : "$@")"
+trace "$(basename "$(test -L "$0" && readlink "$0" || echo "$0")") : $*"
+set -e
 
 run_as_root_or_die
 
@@ -114,5 +115,6 @@ starphleet-cleanup
 # restart syslog
 # TODO: Might be safer to reboot
 restart rsyslog
+# Start starphleet
 start starphleet
 announce *Welcome to Starphleet*

--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -109,5 +109,10 @@ starphleet-buildpacks
 ${DIR}/starphleet-build-base-container
 
 starphleet-cleanup
+
+# In case we mounted a new file system at /var/log during install we
+# restart syslog
+# TODO: Might be safer to reboot
+restart rsyslog
 start starphleet
 announce *Welcome to Starphleet*

--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -13,10 +13,14 @@ set -e
 
 run_as_root_or_die
 
-
 #flush out caches, I know, I know -- but really if you don't do this
 #Linux would rather swap than let go
 sync && echo 3 > /proc/sys/vm/drop_caches
+
+# To support a fresh installation but keep the config in the overlay
+# we need access to the default starphleet config.  Any overrides
+# will happen after perform-over and re-slurpage of tools
+[ -f ../overlay/etc/starphleet ] && source ../overlay/etc/starphleet
 
 ec2_mounts
 

--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -4,6 +4,9 @@
 ### --help
 ###
 ### This will get starphleet on a base machine
+# ******************
+# TODO: Fresh install doesn't have starphleet-launcher yet
+# ******************
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source ${DIR}/tools
 help=$(grep "^### " "$0" | cut -c 5-)
@@ -12,7 +15,7 @@ trace "$(basename "$(test -L "$0" && readlink "$0" || echo "$0")") : $*"
 set -e
 
 # ******************
-# TODO: Figure out how they want to handle this on a fresh install
+# TODO: Figure out how they want to handle this
 # ******************
 export DIR=${DIR}
 export SCRIPT_DIR=${DIR}
@@ -25,7 +28,11 @@ sync && echo 3 > /proc/sys/vm/drop_caches
 
 # To support a fresh installation but keep the config in the overlay
 # we need access to the default starphleet config.  Any overrides
-# will happen after perform-over and re-slurpage of tools
+# will happen after perform-overlay and re-slurpage of tools
+#
+# We declare it in case overlay fails
+declare -A EC2_DRIVES
+# Then try to get the defaults from the starphleet config
 [ -f ../overlay/etc/starphleet ] && source ../overlay/etc/starphleet
 
 ec2_mounts

--- a/scripts/starphleet-launcher
+++ b/scripts/starphleet-launcher
@@ -4,7 +4,7 @@ function abspath {
     if [ -d "${1}" ]; then
         echo "${1}"
     elif [ -e "${1}" ]; then
-        readlink -e "${1}" | xargs dirname
+        echo $(readlink -e "${1}" | xargs dirname)
     else
         echo "$1" does not exist! >&2
         return 127

--- a/scripts/starphleet-launcher
+++ b/scripts/starphleet-launcher
@@ -13,8 +13,8 @@ function abspath {
 
 
 # traditionallly this would be dynamic, but it's really just starphleet here
-COMMAND_PATH=$(abspath $1)
-COMMAND_DIR=$(dirname ${COMMAND_PATH})
+COMMAND_DIR=$(abspath $1)
+COMMAND_PATH="${COMMAND_DIR}/${1}"
 export DIR="${COMMAND_DIR}"
 export SCRIPT_DIR="${COMMAND_DIR}"
 # throw away our self reference

--- a/scripts/starphleet-launcher
+++ b/scripts/starphleet-launcher
@@ -17,7 +17,6 @@ function abspath {
 
 
 # traditionallly this would be dynamic, but it's really just starphleet here
-COMMAND_NAME=starphleet
 COMMAND_PATH=$(abspath $1)
 COMMAND_DIR=$(dirname ${COMMAND_PATH})
 export DIR="${COMMAND_DIR}"

--- a/scripts/starphleet-launcher
+++ b/scripts/starphleet-launcher
@@ -1,10 +1,10 @@
 #! /usr/bin/env bash
 # vim:ft=sh
 function abspath {
-    if [ -d "$1" ]; then
+    if [ -d "${1}" ]; then
         echo "${1}"
-    elif [ -e "$1" ]; then
-        echo $(dirname "${1}") 
+    elif [ -e "${1}" ]; then
+        readlink -e "${1}" | xargs dirname
     else
         echo "$1" does not exist! >&2
         return 127

--- a/scripts/starphleet-launcher
+++ b/scripts/starphleet-launcher
@@ -2,13 +2,9 @@
 # vim:ft=sh
 function abspath {
     if [ -d "$1" ]; then
-        pushd "$1" >/dev/null
-        pwd
-        popd >/dev/null
+        echo "${1}"
     elif [ -e "$1" ]; then
-        pushd "$(dirname "$1")" >/dev/null
-        echo "$(pwd)/$(basename "$1")"
-        popd >/dev/null
+        echo $(dirname "${1}") 
     else
         echo "$1" does not exist! >&2
         return 127

--- a/scripts/starphleet-launcher
+++ b/scripts/starphleet-launcher
@@ -13,8 +13,8 @@ function abspath {
 
 
 # traditionallly this would be dynamic, but it's really just starphleet here
-COMMAND_DIR=$(abspath $1)
-COMMAND_PATH="${COMMAND_DIR}/${1}"
+COMMAND_DIR=$(abspath ${1})
+COMMAND_PATH=$(readlink -e ${1})
 export DIR="${COMMAND_DIR}"
 export SCRIPT_DIR="${COMMAND_DIR}"
 # throw away our self reference

--- a/scripts/tools
+++ b/scripts/tools
@@ -155,12 +155,53 @@ function container_environment() {
 }
 
 function ec2_mounts() {
-  if mount | grep '/var/lib/lxc'; then
-    :
-  else
-    #may have another device on ec2
-    [ -b /dev/xvdb ] && (mount | grep /mnt) &&  mount --bind /mnt /var/lib/lxc || true
+  # Dynamically build storage devices on EC2.
+  #
+  # Priority to who gets the space goes something like
+  #    /dev/xvdb -> /var/lib/lxc
+  #    /dev/xvdc -> /var/starphleet
+  #    /dev/xvdd -> /var/log
+
+  # Drive /dev/xvdb
+  # One place for typos
+  # TODO: This should be a function / copying code for testing
+  DRIVE="/dev/xvdb"
+  if [ -b "${DRIVE}" ]; then
+    # If the drive doesn't have ext4 we presume it isn't setup yet
+    if [[ ! $(file -s "${DRIVE}" | grep ext4) ]]; then
+      mkfs.ext4 "${DRIVE}"
+      mount ${DRIVE} /var/lib/lxc
+      # There are tabs on purpose in here - be careful
+      echo "${DRIVE}	/var/lib/lxc	auto	defaults,nobootwait,comment=cloudconfig	0	2" >> /etc/fstab
+    fi
   fi
+
+  # Drive /dev/xvdc
+  # One place for typos
+  DRIVE="/dev/xvdc"
+  if [ -b "${DRIVE}" ]; then
+    # If the drive doesn't have ext4 we presume it isn't setup yet
+    if [[ ! $(file -s "${DRIVE}" | grep ext4) ]]; then
+      mkfs.ext4 "${DRIVE}"
+      mount ${DRIVE} /var/starphleet
+      # There are tabs on purpose in here - be careful
+      echo "${DRIVE}	/var/starphleet	auto	defaults,nobootwait,comment=cloudconfig	0	2" >> /etc/fstab
+    fi
+  fi
+
+  # Drive /dev/xvdd
+  # One place for typos
+  DRIVE="/dev/xvdd"
+  if [ -b "${DRIVE}" ]; then
+    # If the drive doesn't have ext4 we presume it isn't setup yet
+    if [[ ! $(file -s "${DRIVE}" | grep ext4) ]]; then
+      mkfs.ext4 "${DRIVE}"
+      mount ${DRIVE} /var/log
+      # There are tabs on purpose in here - be careful
+      echo "${DRIVE}	/var/log	auto	defaults,nobootwait,comment=cloudconfig	0	2" >> /etc/fstab
+    fi
+  fi
+
 }
 
 function dev_mode() {

--- a/scripts/tools
+++ b/scripts/tools
@@ -160,7 +160,7 @@ function ec2_mounts() {
   # Priority to who gets the space goes something like
   #    /dev/xvdb -> /var/lib/lxc
   #    /dev/xvdc -> /var/starphleet
-  #    /dev/xvdd -> /var/log
+  #    /dev/xvdd -> /var/log/biglogs
   #
   # Default configuration is in overlay/etc/starphleet
 
@@ -185,6 +185,15 @@ function ec2_mounts() {
       fi
     fi
   done
+
+  # If we have a mount for syslog we move our syslog to the new mount
+  # and symlink back to the old
+  if [ -d /var/log/biglogs ]; then
+    stop rsyslog
+    mv /var/log/syslog /var/log/biglogs/syslog
+    ln -s /var/log/biglogs/syslog /var/log/syslog
+    start rsyslog
+  fi
 }
 
 function dev_mode() {

--- a/scripts/tools
+++ b/scripts/tools
@@ -165,6 +165,12 @@ function ec2_mounts() {
   # Drive /dev/xvdb
   # One place for typos
   # TODO: This should be a function / copying code for testing
+
+  for DRIVE in "${EC2_DRIVES[@]}"
+  do
+    echo "D: ${DRIVE} - ${EC2_DRIVES[$DRIVE]}"
+  done
+  return
   DRIVE="/dev/xvdb"
   if [ -b "${DRIVE}" ]; then
     # If the drive doesn't have ext4 we presume it isn't setup yet

--- a/scripts/tools
+++ b/scripts/tools
@@ -169,6 +169,7 @@ function ec2_mounts() {
   if [ -b "${DRIVE}" ]; then
     # If the drive doesn't have ext4 we presume it isn't setup yet
     if [[ ! $(file -s "${DRIVE}" | grep ext4) ]]; then
+      info Setting up ["${DRIVE}"] for [/var/starphleet]
       mkfs.ext4 "${DRIVE}"
       mount ${DRIVE} /var/lib/lxc
       # Strip any mounts using this device

--- a/scripts/tools
+++ b/scripts/tools
@@ -171,8 +171,12 @@ function ec2_mounts() {
     if [[ ! $(file -s "${DRIVE}" | grep ext4) ]]; then
       mkfs.ext4 "${DRIVE}"
       mount ${DRIVE} /var/lib/lxc
+      # Strip any mounts using this device
+      cat /etc/fstab | grep -v "${DRIVE}" > /tmp/fstab.tmp
       # There are tabs on purpose in here - be careful
-      echo "${DRIVE}	/var/lib/lxc	auto	defaults,nobootwait,comment=cloudconfig	0	2" >> /etc/fstab
+      echo "${DRIVE}	/var/lib/lxc	auto	defaults,nobootwait,comment=cloudconfig	0	2" >> /tmp/fstab.tmp
+      # Move the tmp file into place
+      mv /tmp/fstab.tmp /etc/fstab
     fi
   fi
 
@@ -184,8 +188,12 @@ function ec2_mounts() {
     if [[ ! $(file -s "${DRIVE}" | grep ext4) ]]; then
       mkfs.ext4 "${DRIVE}"
       mount ${DRIVE} /var/starphleet
+      # Strip any mounts using this device
+      cat /etc/fstab | grep -v "${DRIVE}" > /tmp/fstab.tmp
       # There are tabs on purpose in here - be careful
-      echo "${DRIVE}	/var/starphleet	auto	defaults,nobootwait,comment=cloudconfig	0	2" >> /etc/fstab
+      echo "${DRIVE}	/var/starphleet	auto	defaults,nobootwait,comment=cloudconfig	0	2" >> /tmp/fstab.tmp
+      # Move the tmp file into place
+      mv /tmp/fstab.tmp /etc/fstab
     fi
   fi
 
@@ -197,8 +205,12 @@ function ec2_mounts() {
     if [[ ! $(file -s "${DRIVE}" | grep ext4) ]]; then
       mkfs.ext4 "${DRIVE}"
       mount ${DRIVE} /var/log
+      # Strip any mounts using this device
+      cat /etc/fstab | grep -v "${DRIVE}" > /tmp/fstab.tmp
       # There are tabs on purpose in here - be careful
-      echo "${DRIVE}	/var/log	auto	defaults,nobootwait,comment=cloudconfig	0	2" >> /etc/fstab
+      echo "${DRIVE}	/var/log	auto	defaults,nobootwait,comment=cloudconfig	0	2" >> /tmp/fstab.tmp
+      # Move the tmp file into place
+      mv /tmp/fstab.tmp /etc/fstab
     fi
   fi
 

--- a/scripts/tools
+++ b/scripts/tools
@@ -161,9 +161,8 @@ function ec2_mounts() {
   #    /dev/xvdb -> /var/lib/lxc
   #    /dev/xvdc -> /var/starphleet
   #    /dev/xvdd -> /var/log
-
-  # Drive /dev/xvdb
-  # One place for typos
+  #
+  # Default configuration is in overlay/etc/starphleet
 
   for drive in "${!EC2_DRIVES[@]}"
   do
@@ -182,42 +181,6 @@ function ec2_mounts() {
       fi
     fi
   done
-
-  # XXX: Looping instead with array
-  # # Drive /dev/xvdc
-  # # One place for typos
-  # drive="/dev/xvdc"
-  # if [ -b "${DRIVE}" ]; then
-  #   # If the drive doesn't have ext4 we presume it isn't setup yet
-  #   if [[ ! $(file -s "${DRIVE}" | grep ext4) ]]; then
-  #     mkfs.ext4 "${DRIVE}"
-  #     mount ${DRIVE} /var/starphleet
-  #     # Strip any mounts using this device
-  #     cat /etc/fstab | grep -v "${DRIVE}" > /tmp/fstab.tmp
-  #     # There are tabs on purpose in here - be careful
-  #     echo "${DRIVE}	/var/starphleet	auto	defaults,nobootwait,comment=cloudconfig	0	2" >> /tmp/fstab.tmp
-  #     # Move the tmp file into place
-  #     mv /tmp/fstab.tmp /etc/fstab
-  #   fi
-  # fi
-  #
-  # # Drive /dev/xvdd
-  # # One place for typos
-  # DRIVE="/dev/xvdd"
-  # if [ -b "${DRIVE}" ]; then
-  #   # If the drive doesn't have ext4 we presume it isn't setup yet
-  #   if [[ ! $(file -s "${DRIVE}" | grep ext4) ]]; then
-  #     mkfs.ext4 "${DRIVE}"
-  #     mount ${DRIVE} /var/log
-  #     # Strip any mounts using this device
-  #     cat /etc/fstab | grep -v "${DRIVE}" > /tmp/fstab.tmp
-  #     # There are tabs on purpose in here - be careful
-  #     echo "${DRIVE}	/var/log	auto	defaults,nobootwait,comment=cloudconfig	0	2" >> /tmp/fstab.tmp
-  #     # Move the tmp file into place
-  #     mv /tmp/fstab.tmp /etc/fstab
-  #   fi
-  # fi
-
 }
 
 function dev_mode() {

--- a/scripts/tools
+++ b/scripts/tools
@@ -170,11 +170,15 @@ function ec2_mounts() {
       # If the drive doesn't have ext4 we presume it isn't setup yet
       if [[ ! $(file -s "${drive}" | grep ext4) ]]; then
         info Setting up ["${drive}"] for [${EC2_DRIVES[$drive]}]
+        # Format the drive
         mkfs.ext4 "${drive}"
+        # Mount it where it goes
+        mkdir -p "${EC2_DRIVES[$drive]}"
         mount "${drive}" "${EC2_DRIVES[$drive]}"
-        # Strip any mounts using this device
+        # Strip any mounts using this device from fstab
         cat /etc/fstab | grep -v "${drive}" > /tmp/fstab.tmp
-        # There are tabs on purpose in here - be careful
+        # Re-add our config to fstab
+        #   Note: There are tabs on purpose in here - be careful
         echo "${drive}	${EC2_DRIVES[$drive]}	auto	defaults,nobootwait,comment=cloudconfig	0	2" >> /tmp/fstab.tmp
         # Move the tmp file into place
         mv /tmp/fstab.tmp /etc/fstab

--- a/scripts/tools
+++ b/scripts/tools
@@ -164,62 +164,59 @@ function ec2_mounts() {
 
   # Drive /dev/xvdb
   # One place for typos
-  # TODO: This should be a function / copying code for testing
 
-  for DRIVE in "${!EC2_DRIVES[@]}"
+  for drive in "${!EC2_DRIVES[@]}"
   do
-    echo D: ${DRIVE} - ${EC2_DRIVES[$DRIVE]}
+    if [ -b "${drive}" ]; then
+      # If the drive doesn't have ext4 we presume it isn't setup yet
+      if [[ ! $(file -s "${drive}" | grep ext4) ]]; then
+        info Setting up ["${drive}"] for [${EC2_DRIVES[$drive]}]
+        mkfs.ext4 "${drive}"
+        mount "${drive}" "${EC2_DRIVES[$drive]}"
+        # Strip any mounts using this device
+        cat /etc/fstab | grep -v "${drive}" > /tmp/fstab.tmp
+        # There are tabs on purpose in here - be careful
+        echo "${drive}	${EC2_DRIVES[$drive]}	auto	defaults,nobootwait,comment=cloudconfig	0	2" >> /tmp/fstab.tmp
+        # Move the tmp file into place
+        mv /tmp/fstab.tmp /etc/fstab
+      fi
+    fi
   done
-  return
-  DRIVE="/dev/xvdb"
-  if [ -b "${DRIVE}" ]; then
-    # If the drive doesn't have ext4 we presume it isn't setup yet
-    if [[ ! $(file -s "${DRIVE}" | grep ext4) ]]; then
-      info Setting up ["${DRIVE}"] for [/var/lib/lxc]
-      mkfs.ext4 "${DRIVE}"
-      mount ${DRIVE} /var/lib/lxc
-      # Strip any mounts using this device
-      cat /etc/fstab | grep -v "${DRIVE}" > /tmp/fstab.tmp
-      # There are tabs on purpose in here - be careful
-      echo "${DRIVE}	/var/lib/lxc	auto	defaults,nobootwait,comment=cloudconfig	0	2" >> /tmp/fstab.tmp
-      # Move the tmp file into place
-      mv /tmp/fstab.tmp /etc/fstab
-    fi
-  fi
 
-  # Drive /dev/xvdc
-  # One place for typos
-  DRIVE="/dev/xvdc"
-  if [ -b "${DRIVE}" ]; then
-    # If the drive doesn't have ext4 we presume it isn't setup yet
-    if [[ ! $(file -s "${DRIVE}" | grep ext4) ]]; then
-      mkfs.ext4 "${DRIVE}"
-      mount ${DRIVE} /var/starphleet
-      # Strip any mounts using this device
-      cat /etc/fstab | grep -v "${DRIVE}" > /tmp/fstab.tmp
-      # There are tabs on purpose in here - be careful
-      echo "${DRIVE}	/var/starphleet	auto	defaults,nobootwait,comment=cloudconfig	0	2" >> /tmp/fstab.tmp
-      # Move the tmp file into place
-      mv /tmp/fstab.tmp /etc/fstab
-    fi
-  fi
-
-  # Drive /dev/xvdd
-  # One place for typos
-  DRIVE="/dev/xvdd"
-  if [ -b "${DRIVE}" ]; then
-    # If the drive doesn't have ext4 we presume it isn't setup yet
-    if [[ ! $(file -s "${DRIVE}" | grep ext4) ]]; then
-      mkfs.ext4 "${DRIVE}"
-      mount ${DRIVE} /var/log
-      # Strip any mounts using this device
-      cat /etc/fstab | grep -v "${DRIVE}" > /tmp/fstab.tmp
-      # There are tabs on purpose in here - be careful
-      echo "${DRIVE}	/var/log	auto	defaults,nobootwait,comment=cloudconfig	0	2" >> /tmp/fstab.tmp
-      # Move the tmp file into place
-      mv /tmp/fstab.tmp /etc/fstab
-    fi
-  fi
+  # XXX: Looping instead with array
+  # # Drive /dev/xvdc
+  # # One place for typos
+  # drive="/dev/xvdc"
+  # if [ -b "${DRIVE}" ]; then
+  #   # If the drive doesn't have ext4 we presume it isn't setup yet
+  #   if [[ ! $(file -s "${DRIVE}" | grep ext4) ]]; then
+  #     mkfs.ext4 "${DRIVE}"
+  #     mount ${DRIVE} /var/starphleet
+  #     # Strip any mounts using this device
+  #     cat /etc/fstab | grep -v "${DRIVE}" > /tmp/fstab.tmp
+  #     # There are tabs on purpose in here - be careful
+  #     echo "${DRIVE}	/var/starphleet	auto	defaults,nobootwait,comment=cloudconfig	0	2" >> /tmp/fstab.tmp
+  #     # Move the tmp file into place
+  #     mv /tmp/fstab.tmp /etc/fstab
+  #   fi
+  # fi
+  #
+  # # Drive /dev/xvdd
+  # # One place for typos
+  # DRIVE="/dev/xvdd"
+  # if [ -b "${DRIVE}" ]; then
+  #   # If the drive doesn't have ext4 we presume it isn't setup yet
+  #   if [[ ! $(file -s "${DRIVE}" | grep ext4) ]]; then
+  #     mkfs.ext4 "${DRIVE}"
+  #     mount ${DRIVE} /var/log
+  #     # Strip any mounts using this device
+  #     cat /etc/fstab | grep -v "${DRIVE}" > /tmp/fstab.tmp
+  #     # There are tabs on purpose in here - be careful
+  #     echo "${DRIVE}	/var/log	auto	defaults,nobootwait,comment=cloudconfig	0	2" >> /tmp/fstab.tmp
+  #     # Move the tmp file into place
+  #     mv /tmp/fstab.tmp /etc/fstab
+  #   fi
+  # fi
 
 }
 

--- a/scripts/tools
+++ b/scripts/tools
@@ -166,7 +166,7 @@ function ec2_mounts() {
   # One place for typos
   # TODO: This should be a function / copying code for testing
 
-  for DRIVE in "${EC2_DRIVES[@]}"
+  for DRIVE in "${!EC2_DRIVES[@]}"
   do
     echo D: ${DRIVE} - ${EC2_DRIVES[$DRIVE]}
   done

--- a/scripts/tools
+++ b/scripts/tools
@@ -168,7 +168,7 @@ function ec2_mounts() {
 
   for DRIVE in "${EC2_DRIVES[@]}"
   do
-    echo 'D: ${DRIVE} - ${EC2_DRIVES["$DRIVE"]}'
+    echo D: ${DRIVE} - ${EC2_DRIVES[$DRIVE]}
   done
   return
   DRIVE="/dev/xvdb"

--- a/scripts/tools
+++ b/scripts/tools
@@ -188,12 +188,13 @@ function ec2_mounts() {
 
   # If we have a mount for syslog we move our syslog to the new mount
   # and symlink back to the old
-  if [ -d /var/log/biglogs ]; then
+  if [ -d /var/log/biglogs ] && [ ! -L /var/log/syslog ]; then
     stop rsyslog
     mv /var/log/syslog /var/log/biglogs/syslog
     ln -s /var/log/biglogs/syslog /var/log/syslog
     start rsyslog
   fi
+
 }
 
 function dev_mode() {

--- a/scripts/tools
+++ b/scripts/tools
@@ -169,7 +169,7 @@ function ec2_mounts() {
   if [ -b "${DRIVE}" ]; then
     # If the drive doesn't have ext4 we presume it isn't setup yet
     if [[ ! $(file -s "${DRIVE}" | grep ext4) ]]; then
-      info Setting up ["${DRIVE}"] for [/var/starphleet]
+      info Setting up ["${DRIVE}"] for [/var/lib/lxc]
       mkfs.ext4 "${DRIVE}"
       mount ${DRIVE} /var/lib/lxc
       # Strip any mounts using this device

--- a/scripts/tools
+++ b/scripts/tools
@@ -168,7 +168,7 @@ function ec2_mounts() {
 
   for DRIVE in "${EC2_DRIVES[@]}"
   do
-    echo "D: ${DRIVE} - ${EC2_DRIVES[$DRIVE]}"
+    echo 'D: ${DRIVE} - ${EC2_DRIVES["$DRIVE"]}'
   done
   return
   DRIVE="/dev/xvdb"

--- a/webinstall
+++ b/webinstall
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+REPO="https://github.com/benjamin7062/starphleet.git"
+apt-get install -y git
+# TODO: branch should be removed
+git clone -b install_modifications https://github.com/benjamin7062/starphleet.git
+cd starphleet/scripts

--- a/webinstall
+++ b/webinstall
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
+# TODO: All the paths need to change on final
+## TO USE THIS SCRIPT PASTE THE FOLLOWING INTO THE TERMINAL:
+
+# bash -c "$(curl -s https://raw.githubusercontent.com/benjamin7062/starphleet/install_modifications/webinstall)"
+
 ##############################################################################
 ## Author:          Benjamin Hudgens
 ## Date:            March 18, 2015
 ##
 ## Description:     Fully Deploy starphleet from the command line
 ##
-## Usage:
-##    bash -c $(curl <url to this script>)
-##    bash -c $(curl https://raw.githubusercontent.com/benjamin7062/starphleet/install_modifications/webinstall)
 ##############################################################################
 ## Locations to this repo
 STARPHLEET_REPO="https://github.com/benjamin7062/starphleet.git"

--- a/webinstall
+++ b/webinstall
@@ -12,7 +12,7 @@
 ##
 ##############################################################################
 ## Locations to this repo
-STARPHLEET_REPO="https://github.com/benjamin7062/starphleet.git"
+STARPHLEET_REPO="https://github.com/wballard/starphleet.git"
 
 ##############################################################################
 ## Main Foo

--- a/webinstall
+++ b/webinstall
@@ -2,7 +2,7 @@
 # TODO: All the paths need to change on final
 ## TO USE THIS SCRIPT PASTE THE FOLLOWING INTO THE TERMINAL:
 
-# bash -c "$(curl -s https://raw.githubusercontent.com/benjamin7062/starphleet/install_modifications/webinstall)"
+# bash -c "$(curl -s https://raw.githubusercontent.com/wballard/starphleet/master/webinstall)"
 
 ##############################################################################
 ## Author:          Benjamin Hudgens
@@ -18,7 +18,7 @@ STARPHLEET_REPO="https://github.com/benjamin7062/starphleet.git"
 ## Main Foo
 ##############################################################################
 
-read -p "Please paste the SSH git URL to your headquarters:" HEADQUARTERS_URL
+read -p "Please paste the SSH git URL to your headquarters:  " HEADQUARTERS_URL
 
 # We're gonna need git
 apt-get install -y git
@@ -43,8 +43,6 @@ Installation is not finished.
 
 You need to copy your GitHub ssh private key to:
 
-${PRIVATE_KEYS}
-
-Once complete the magic should begin
+   ${PRIVATE_KEYS}
 
 EOF

--- a/webinstall
+++ b/webinstall
@@ -23,7 +23,7 @@ read -p "Please paste the SSH git URL to your headquarters:  " HEADQUARTERS_URL
 # We're gonna need git
 apt-get install -y git
 # Now grab this repo
-git clone -b install_modifications ${STARPHLEET_REPO}
+git clone ${STARPHLEET_REPO}
 # Head into scripts
 cd starphleet/scripts
 # Move launcher into place

--- a/webinstall
+++ b/webinstall
@@ -33,6 +33,8 @@ cp ./starphleet-launcher /usr/bin
 # Set the headquarters
 starphleet-headquarters ${HEADQUARTERS_URL}
 
+source `which tools`
+
 cat << EOF
 
 NOTICE:

--- a/webinstall
+++ b/webinstall
@@ -15,7 +15,7 @@ STARPHLEET_REPO="https://github.com/benjamin7062/starphleet.git"
 ## Main Foo
 ##############################################################################
 
-read "Please paste the SSH git URL to your headquarters" HEADQUARTERS_URL
+read -p "Please paste the SSH git URL to your headquarters:\n" HEADQUARTERS_URL
 
 # We're gonna need git
 apt-get install -y git

--- a/webinstall
+++ b/webinstall
@@ -1,7 +1,45 @@
 #!/usr/bin/env bash
+##############################################################################
+## Author:          Benjamin Hudgens
+## Date:            March 18, 2015
+##
+## Description:     Fully Deploy starphleet from the command line
+##
+## Usage:
+##    curl <url to this script> | bash
+##############################################################################
+## Locations to this repo
+STARPHLEET_REPO="https://github.com/benjamin7062/starphleet.git"
 
-REPO="https://github.com/benjamin7062/starphleet.git"
+##############################################################################
+## Main Foo
+##############################################################################
+
+read "Please paste the SSH git URL to your headquarters" HEADQUARTERS_URL
+
+# We're gonna need git
 apt-get install -y git
-# TODO: branch should be removed
-git clone -b install_modifications https://github.com/benjamin7062/starphleet.git
+# Now grab this repo
+git clone -b install_modifications ${STARPHLEET_REPO}
+# Head into scripts
 cd starphleet/scripts
+# Move launcher into place
+cp ./starphleet-launcher /usr/bin
+# Let the magic begin
+./starphleet-install
+# Set the headquarters
+starphleet-headquarters ${HEADQUARTERS_URL}
+
+cat << EOF
+
+NOTICE:
+
+Installation is not finished.
+
+You need to copy your GitHub ssh private key to:
+
+${PRIVATE_KEYS}
+
+Once complete the magic should begin
+
+EOF

--- a/webinstall
+++ b/webinstall
@@ -17,29 +17,29 @@ STARPHLEET_REPO="https://github.com/benjamin7062/starphleet.git"
 
 read -p "Please paste the SSH git URL to your headquarters:\n" HEADQUARTERS_URL
 
-# We're gonna need git
-apt-get install -y git
-# Now grab this repo
-git clone -b install_modifications ${STARPHLEET_REPO}
-# Head into scripts
-cd starphleet/scripts
-# Move launcher into place
-cp ./starphleet-launcher /usr/bin
-# Let the magic begin
-./starphleet-install
-# Set the headquarters
-starphleet-headquarters ${HEADQUARTERS_URL}
-
-cat << EOF
-
-NOTICE:
-
-Installation is not finished.
-
-You need to copy your GitHub ssh private key to:
-
-${PRIVATE_KEYS}
-
-Once complete the magic should begin
-
-EOF
+# # We're gonna need git
+# apt-get install -y git
+# # Now grab this repo
+# git clone -b install_modifications ${STARPHLEET_REPO}
+# # Head into scripts
+# cd starphleet/scripts
+# # Move launcher into place
+# cp ./starphleet-launcher /usr/bin
+# # Let the magic begin
+# ./starphleet-install
+# # Set the headquarters
+# starphleet-headquarters ${HEADQUARTERS_URL}
+#
+# cat << EOF
+#
+# NOTICE:
+#
+# Installation is not finished.
+#
+# You need to copy your GitHub ssh private key to:
+#
+# ${PRIVATE_KEYS}
+#
+# Once complete the magic should begin
+#
+# EOF

--- a/webinstall
+++ b/webinstall
@@ -6,7 +6,8 @@
 ## Description:     Fully Deploy starphleet from the command line
 ##
 ## Usage:
-##    curl <url to this script> | bash
+##    bash -c $(curl <url to this script>)
+##    bash -c $(curl https://raw.githubusercontent.com/benjamin7062/starphleet/install_modifications/webinstall)
 ##############################################################################
 ## Locations to this repo
 STARPHLEET_REPO="https://github.com/benjamin7062/starphleet.git"
@@ -15,31 +16,31 @@ STARPHLEET_REPO="https://github.com/benjamin7062/starphleet.git"
 ## Main Foo
 ##############################################################################
 
-read -p "Please paste the SSH git URL to your headquarters:\n" HEADQUARTERS_URL
+read -p "Please paste the SSH git URL to your headquarters:" HEADQUARTERS_URL
 
-# # We're gonna need git
-# apt-get install -y git
-# # Now grab this repo
-# git clone -b install_modifications ${STARPHLEET_REPO}
-# # Head into scripts
-# cd starphleet/scripts
-# # Move launcher into place
-# cp ./starphleet-launcher /usr/bin
-# # Let the magic begin
-# ./starphleet-install
-# # Set the headquarters
-# starphleet-headquarters ${HEADQUARTERS_URL}
-#
-# cat << EOF
-#
-# NOTICE:
-#
-# Installation is not finished.
-#
-# You need to copy your GitHub ssh private key to:
-#
-# ${PRIVATE_KEYS}
-#
-# Once complete the magic should begin
-#
-# EOF
+# We're gonna need git
+apt-get install -y git
+# Now grab this repo
+git clone -b install_modifications ${STARPHLEET_REPO}
+# Head into scripts
+cd starphleet/scripts
+# Move launcher into place
+cp ./starphleet-launcher /usr/bin
+# Let the magic begin
+./starphleet-install
+# Set the headquarters
+starphleet-headquarters ${HEADQUARTERS_URL}
+
+cat << EOF
+
+NOTICE:
+
+Installation is not finished.
+
+You need to copy your GitHub ssh private key to:
+
+${PRIVATE_KEYS}
+
+Once complete the magic should begin
+
+EOF


### PR DESCRIPTION
Example:

- bash -c "$(curl -s https://raw.githubusercontent.com/wballard/starphleet/master/webinstall)"
- [Upload Key]

This commit will fully configure EC2 drives on the machine and mount them appropriately.  Priority is given in the following order for mountable devices:

    /dev/xvdb -> /var/lib/lxc
    /dev/xvdc -> /var/starphleet
    /dev/xvdd -> /var/log

If a drive is not found because one is not available it is simply ignored.

Slight modifications were made to starphleet-launcher because it would only work if the commands were in /usr/bin and not on a clean installation.  Please review.. I'm sure I did it wrong.  =)

