### PR TITLE
Make nginx logs less noisy

### DIFF
--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -95,7 +95,7 @@ if [[ "${ldap}" != '' && "${ldap}" != '-' ]]; then
   # see http://forum.nginx.org/read.php?2,242713,242742#msg-242742
   # note: this needs an auth_basic that alway fails and has the same name as auth_ldap
   echo "  satisfy any;" >> "${MOUNT_CONF}"
-  echo "  allow 10.0.3.0/8;" >> "${MOUNT_CONF}"
+  echo "  allow 10.0.0.0/8;" >> "${MOUNT_CONF}"
   # Future proof
   echo "  allow 172.16.0.0/12;" >> "${MOUNT_CONF}"
   # Allow no auth


### PR DESCRIPTION
- Either need to specify /24 - or fix subnet

Example:

2015/03/19 17:28:34 [warn] 17597#0: low address bits of 10.0.3.0/8 are
meaningless in
/var/starphleet/nginx/published/%22%2Fsp-preview%22.conf:25
2015/03/19 17:28:34 [warn] 17597#0: low address bits of 10.0.3.0/8 are
meaningless in /var/starphleet/nginx/published/%22%2Fspquery%22.conf:25
2015/03/19 17:28:34 [warn] 17597#0: low address bits of 10.0.3.0/8 are
meaningless in
/var/starphleet/nginx/published/%22%2Fswitchboard%22.conf:25
2015/03/19 17:28:34 [warn] 17597#0: low address bits of 10.0.3.0/8 are
meaningless in
/var/starphleet/nginx/published/%22%2Ftaxonomizer%22.conf:25
2015/03/19 17:28:34 [warn] 17597#0: low address bits of 10.0.3.0/8 are
meaningless in
/var/starphleet/nginx/published/%22%2Ftrackingexpress%22.conf:25
2015/03/19 17:28:34 [warn] 17597#0: low address bits of 10.0.3.0/8 are
meaningless in /var/starphleet/nginx/published/%22%2Ftraining%22.conf:26
2015/03/19 17:28:34 [warn] 17597#0: low address bits of 10.0.3.0/8 are
meaningless in /var/starphleet/nginx/published/%22%2Ftrends%22.conf:25
2015/03/19 17:28:34 [warn] 17597#0: low address bits of 10.0.3.0/8 are
meaningless in
/var/starphleet/nginx/published/%22%2Fui-toolkit-auth%22.conf:26
2015/03/19 17:28:34 [warn] 17597#0: low address bits of 10.0.3.0/8 are
meaningless in
/var/starphleet/nginx/published/%22%2Fvolumizer%22.conf:25