### PR TITLE
Bug Fix - Orphan reaper needs to check for orders

### DIFF
--- a/scripts/starphleet-orphan-reaper
+++ b/scripts/starphleet-orphan-reaper
@@ -17,5 +17,9 @@ for container in $(lxc-ls); do
   # Yank the sha(s) off the container
   SERVICE=$(echo ${container:0:${#container}-16})
   # If no orders correspond with the service - reap it
-  [ ! -d "${HEADQUARTERS_LOCAL}/${SERVICE}" ] && starphleet-reaper zzzzzzzzz "${SERVICE}"
+  if [ ! -f "${HEADQUARTERS_LOCAL}/${SERVICE}/orders" ]; then
+    starphleet-reaper zzzzzzzzz "${SERVICE}"
+    [ -d "${HEADQUARTERS_LOCAL}/${SERVICE}" ] && rm -rf "${HEADQUARTERS_LOCAL}/${SERVICE}"
+    [ -d "${CURRENT_ORDERS}/${SERVICE}" ] && rm -rf "${CURRENT_ORDERS}/${SERVICE}"
+  fi
 done


### PR DESCRIPTION
- In production checking for the orders directory is not enough since we
  checkout git dirs into that directory.  In this case, the directory is
  not empty when git tries to remove it so they stay around.  Moving to
  checking for the orders file specifically.. and then cleaning up
  ${CURRENT_ORDERS} and ${HEADQUARTERS_LOCAL} when appropriate