### PR TITLE
Split out the nginx log to retain more traffic

### DIFF
--- a/overlay/etc/logrotate.d/upstart
+++ b/overlay/etc/logrotate.d/upstart
@@ -1,3 +1,11 @@
+/var/log/upstart/starphleet_nginx.log {
+        missingok
+        rotate 4
+        size 10M
+        nocompress
+        notifempty
+        nocreate
+}
 /var/log/upstart/*.log {
         missingok
         rotate 1


### PR DESCRIPTION
Step one - isolate the nginx logrotate to allow nginx log retention.
Often need the nginx logs to lookup called traffic and validate user agents/time of requests.
