### PR TITLE
Centralize all beta configuration

### DIFF
--- a/scripts/starphleet-beta-groups
+++ b/scripts/starphleet-beta-groups
@@ -50,7 +50,7 @@ do
 
   # Get only the 'name' of these orders
   ORDER_NAME=$(echo "${ORDERS_FILE}" | sed -e 's[/orders$[[' | sed -e "s[${HEADQUARTERS_LOCAL}/\?[[")
-  # Get the beta configuration
+  # Beta config name
   BETA_CONF="${NGINX_CONF}/published/$(urlencode \"${ORDER_NAME}\").beta"
 
   echo "" > "${BETA_CONF}"

--- a/scripts/starphleet-beta-groups
+++ b/scripts/starphleet-beta-groups
@@ -1,18 +1,18 @@
-#!/usr/bin/env bash
+#!/usr/bin/env starphleet-launcher
 ### Usage:
 ###    starphleet-beta-groups
 ### --help
 ###
 ### Configure named beta group maps.
 ###
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source ${DIR}/tools
-help=$(grep "^### " "$0" | cut -c 5-)
-eval "$(${DIR}/docopts -h "$help" -V "$version" : "$@")"
-trace "$(basename "$(test -L "$0" && readlink "$0" || echo "$0")") : $*"
-set -e
 
+die_on_error
+
+# Purge all beta groups and beta configs
 [ -d "${NGINX_CONF}/beta_groups" ]  && rm -rf "${NGINX_CONF}/beta_groups"
+rm "${HEADQUARTERS_LOCAL}/published/*.beta"
+
+# Make the beta_group again
 mkdir -p "${NGINX_CONF}/beta_groups"
 
 #set a beta group if the remote user is in the list of beta users
@@ -37,3 +37,38 @@ do
   done
   echo "  }" >> "${BETA_GROUP_CONF}"
 done
+
+# Go through all the orders and generate all the beta configs
+for ORDERS_FILE in $(find "${HEADQUARTERS_LOCAL}" | grep '/orders$')
+do
+  # Orders will contain BETAS as an array.. so we clear and declare
+  # the BETAS variable as an associative array
+  unset BETAS
+  declare -A BETAS
+  # Slurp in the beta configs for this orders file by running it
+  run_orders "${ORDERS_FILE}"
+
+  # Get only the 'name' of these orders
+  ORDER_NAME=$(echo "${ORDERS_FILE}" | sed -e 's[/orders$[[' | sed -e "s[${HEADQUARTERS_LOCAL}/\?[[")
+  # Get the beta configuration
+  BETA_CONF="${NGINX_CONF}/published/$(urlencode \"${ORDER_NAME}\").beta"
+
+  echo "" > "${BETA_CONF}"
+  for beta in "${!BETAS[@]}"
+  do
+    # Beta groups need a corresponding file with a list of users
+    # for the beta.  If that file doesn't exist the following
+    # will create variable references that don't exist.  We
+    # check to see if the corresponding file is there before we
+    # create the config and skip otherwise
+    [ ! -f "${HEADQUARTERS_LOCAL}/beta_groups/${beta}" ] && continue
+    echo "  if (\$starphleet_beta_${beta}) {" >> "${BETA_CONF}"
+    echo "    rewrite ^${public_url}/(.*) ${BETAS[$beta]}/\$1 last;" >> "${BETA_CONF}"
+    echo "  }" >> "${BETA_CONF}"
+    echo "  if (\$starphleet_beta_${beta}_cookie) {" >> "${BETA_CONF}"
+    echo "    rewrite ^${public_url}/(.*) ${BETAS[$beta]}/\$1 last;" >> "${BETA_CONF}"
+    echo "  }" >> "${BETA_CONF}"
+  done
+done
+
+starphleet-hup-nginx

--- a/scripts/starphleet-beta-groups
+++ b/scripts/starphleet-beta-groups
@@ -7,10 +7,12 @@
 ###
 
 die_on_error
+run_as_root_or_die
 
 # Purge all beta groups and beta configs
 [ -d "${NGINX_CONF}/beta_groups" ]  && rm -rf "${NGINX_CONF}/beta_groups"
-rm "${HEADQUARTERS_LOCAL}/published/*.beta"
+# Try to remove beta files or.. exit happy if none exist
+rm "${HEADQUARTERS_LOCAL}/published/*.beta" || true
 
 # Make the beta_group again
 mkdir -p "${NGINX_CONF}/beta_groups"

--- a/scripts/starphleet-cleanup
+++ b/scripts/starphleet-cleanup
@@ -22,4 +22,4 @@ test -d "${CURRENT_ORDERS}" && rm -rf "${CURRENT_ORDERS}"
 #unpublish services from nginx
 test -d "${NGINX_CONF}/published" && rm -rf "${NGINX_CONF}/published"
 test -d "${NGINX_CONF}/published_bare" && rm -rf "${NGINX_CONF}/published_bare"
-test -d "${NGINX_CONF}/published_bare" && rm -rf "${NGINX_CONF}/beta_groups"
+test -d "${NGINX_CONF}/beta_groups" && rm -rf "${NGINX_CONF}/beta_groups"

--- a/scripts/starphleet-cleanup
+++ b/scripts/starphleet-cleanup
@@ -1,13 +1,9 @@
-#!/usr/bin/env bash
+#!/usr/bin/env starphleet-launcher
 ### Usage:
 ###    starphleet-cleanup
 ### --help
 ###
 ### Call this to toss all starphleet state on shutdown
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source ${DIR}/tools
-help=$(grep "^### " "$0" | cut -c 5-)
-eval "$(${DIR}/docopts -h "$help" -V "$version" : "$@")"
 
 test -d "${STARPHLEET_ROOT}/node_modules" && rm -rf "${STARPHLEET_ROOT}/node_modules"
 test -d ${STARPHLEET_TMP} && rm -rf ${STARPHLEET_TMP}/*

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -110,22 +110,7 @@ if [[ "${ldap}" != '' && "${ldap}" != '-' ]]; then
   echo "  allow 172.33.0.0/16;" >> "${MOUNT_CONF}"
 fi
 
-echo "" > "${BETA_CONF}"
-for beta in "${!BETAS[@]}"
-do
-  # Beta groups need a corresponding file with a list of users
-  # for the beta.  If that file doesn't exist the following
-  # will create variable references that don't exist.  We
-  # check to see if the corresponding file is there before we
-  # create the config and skip otherwise
-  [ ! -f "${HEADQUARTERS_LOCAL}/beta_groups/${beta}" ] && continue
-  echo "  if (\$starphleet_beta_${beta}) {" >> "${BETA_CONF}"
-  echo "    rewrite ^${public_url}/(.*) ${BETAS[$beta]}/\$1 last;" >> "${BETA_CONF}"
-  echo "  }" >> "${BETA_CONF}"
-  echo "  if (\$starphleet_beta_${beta}_cookie) {" >> "${BETA_CONF}"
-  echo "    rewrite ^${public_url}/(.*) ${BETAS[$beta]}/\$1 last;" >> "${BETA_CONF}"
-  echo "  }" >> "${BETA_CONF}"
-done
+
 
 #closing off the location
 echo '}' >> "${MOUNT_CONF}"

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -10,6 +10,8 @@
 ### Optionally, you can 'deep publish' or alias further into the container.
 run_as_root_or_die
 
+# Even though we won't use this variable here we still
+# want to declare it in case the orders don't
 declare -A BETAS
 run_orders "${orders}"
 
@@ -21,8 +23,6 @@ fi
 MOUNT_CONF="${NGINX_CONF}/published/$(urlencode \"${public_url}\").conf"
 #mount this service over a port
 BARE_CONF="${NGINX_CONF}/published_bare/$(urlencode \"${public_url}\").conf"
-#rewrites for beta support
-BETA_CONF="${NGINX_CONF}/published/$(urlencode \"${public_url}\").beta"
 #redirect your urls to lxc
 REDIRECT_CONF="${NGINX_CONF}/published/$(urlencode \"${public_url}\").redirect"
 #mount this service over a path


### PR DESCRIPTION
- Pull beta configuration out of starphleet-publish completely.
- All beta configuration occurs in monitor_headquarters and is
  completely rebuilt each time starphleet-beta-groups is called
- for:igroff@glgroup.com