### PR TITLE
Bug: Beta group re-write rule broken

### DIFF
--- a/scripts/starphleet-beta-groups
+++ b/scripts/starphleet-beta-groups
@@ -65,10 +65,10 @@ do
     # create the config and skip otherwise
     [ ! -f "${HEADQUARTERS_LOCAL}/beta_groups/${beta}" ] && continue
     echo "  if (\$starphleet_beta_${beta}) {" >> "${BETA_CONF}"
-    echo "    rewrite ^${public_url}/(.*) ${BETAS[$beta]}/\$1 last;" >> "${BETA_CONF}"
+    echo "    rewrite ^/${ORDER_NAME}/(.*) ${BETAS[$beta]}/\$1 last;" >> "${BETA_CONF}"
     echo "  }" >> "${BETA_CONF}"
     echo "  if (\$starphleet_beta_${beta}_cookie) {" >> "${BETA_CONF}"
-    echo "    rewrite ^${public_url}/(.*) ${BETAS[$beta]}/\$1 last;" >> "${BETA_CONF}"
+    echo "    rewrite ^/${ORDER_NAME}/(.*) ${BETAS[$beta]}/\$1 last;" >> "${BETA_CONF}"
     echo "  }" >> "${BETA_CONF}"
   done
 done


### PR DESCRIPTION
Users on betas getting improperly rewritten to outer space.  The rewrite rules were missing the service name.

Missing slash and var name wrong
