### PR TITLE
BUG: Add maxdepth to find(s)

### DIFF
--- a/overlay/etc/init/starphleet_monitor_orders.conf
+++ b/overlay/etc/init/starphleet_monitor_orders.conf
@@ -17,7 +17,7 @@ script
     ORDERS_SHA="${CURRENT_SHA}"
 
     #Clean up Removed Orders
-    for ORDER_FILE in $(find "${CURRENT_ORDERS}" -type f -iname ".starphleetstatus")
+    for ORDER_FILE in $(find "${CURRENT_ORDERS}" -maxdepth 2 -type f -iname ".starphleetstatus")
     do
       ORDER_FILE="${ORDER_FILE%/*}"
       ORDER_FILE="${ORDER_FILE##*/}"
@@ -42,7 +42,7 @@ script
 
     #auto deploy each ordered service, really need to use grep here
     #find doesn't work out on that / pattern
-    for order in $(find "${HEADQUARTERS_LOCAL}" | grep '/orders$')
+    for order in $(find "${HEADQUARTERS_LOCAL}" -maxdepth 2 | grep '/orders$')
     do
       trace -----------------------
       info checking ${order}

--- a/overlay/etc/init/starphleet_monitor_remotes.conf
+++ b/overlay/etc/init/starphleet_monitor_remotes.conf
@@ -12,7 +12,7 @@ script
     source `which tools`
     sleep "${STARPHLEET_PULSE}"
     #auto deploy each ordered remote
-    for remote in $(find "${HEADQUARTERS_LOCAL}" | grep '/remote$')
+    for remote in $(find "${HEADQUARTERS_LOCAL}" -maxdepth 2 | grep '/remote$')
     do
       if [ -d /hosthome ] ; then
         export LOCAL_DIRECTORY=$(echo "${remote}" | sed -e 's[/remote$[[' | sed -e "s[^${HEADQUARTERS_LOCAL}/\?[${STARPHLEET_DEV_DIR}/[")

--- a/scripts/starphleet-beta-groups
+++ b/scripts/starphleet-beta-groups
@@ -18,7 +18,7 @@ rm "${NGINX_CONF}"/published/*.beta || true
 mkdir -p "${NGINX_CONF}/beta_groups"
 
 #set a beta group if the remote user is in the list of beta users
-for BETA_GROUP in $(find "${HEADQUARTERS_LOCAL}/beta_groups" -type f)
+for BETA_GROUP in $(find "${HEADQUARTERS_LOCAL}/beta_groups" -maxdepth 1 -type f)
 do
   info beta group $(basename ${BETA_GROUP})
   #user authentication style
@@ -41,7 +41,7 @@ do
 done
 
 # Go through all the orders and generate all the beta configs
-for ORDERS_FILE in $(find "${HEADQUARTERS_LOCAL}" | grep '/orders$')
+for ORDERS_FILE in $(find "${HEADQUARTERS_LOCAL}" -maxdepth 2 | grep '/orders$')
 do
   # Orders will contain BETAS as an array.. so we clear and declare
   # the BETAS variable as an associative array

--- a/scripts/starphleet-ldap-servers
+++ b/scripts/starphleet-ldap-servers
@@ -16,7 +16,7 @@ set -e
 [ -d "${NGINX_CONF}/ldap_servers" ]  && rm -rf "${NGINX_CONF}/ldap_servers"
 mkdir -p "${NGINX_CONF}/ldap_servers"
 
-for LDAP_SERVER in $(find "${HEADQUARTERS_LOCAL}/ldap_servers" -type f)
+for LDAP_SERVER in $(find "${HEADQUARTERS_LOCAL}/ldap_servers" -maxdepth 1 -type f)
 do
   info ${LDAP_SERVER}
   source ${LDAP_SERVER}

--- a/scripts/starphleet-status
+++ b/scripts/starphleet-status
@@ -60,7 +60,7 @@ EOF
   else
     FILTER="starphleetstatus"
   fi
-  for status in $(find "${CURRENT_ORDERS}" | grep 'starphleetstatus$' | grep ${FILTER})
+  for status in $(find "${CURRENT_ORDERS}" -maxdepth 2 | grep 'starphleetstatus$' | grep ${FILTER})
   do
     STATUS=$(cat "${status}")
     ORDER="$(dirname ${status} | sed -e "s[${CURRENT_ORDERS}/\?[[")"


### PR DESCRIPTION
- monitor_orders will grab git directories.  If those git directories
  contain some of the key files we look for in our finds (like a file
  named orders or remote) it confuses the system into thinking these are
  more deployments