### PR TITLE
Bug: Files not existing in starphleet.d hurt set-e

### DIFF
--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -40,6 +40,7 @@ echo 24576 > /sys/module/nf_conntrack/parameters/hashsize
 
 # Machine specific configs
 mkdir -p /etc/starphleet.d
+touch /etc/starphleet.d/overrides
 
 # If starphleet is deployed in a EC2 environment we append the region configuration
 # to the global starphleet config

--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -40,7 +40,6 @@ echo 24576 > /sys/module/nf_conntrack/parameters/hashsize
 
 # Machine specific configs
 mkdir -p /etc/starphleet.d
-touch /etc/starphleet.d/overrides
 
 # If starphleet is deployed in a EC2 environment we append the region configuration
 # to the global starphleet config

--- a/scripts/tools
+++ b/scripts/tools
@@ -134,8 +134,8 @@ function run_orders()
   }
 
   redirect_to () {
-    # although it is perfectly ok ( it seems ) to redeclare an array when 
-    # one of the same name exists ( it doesn't seem to do anything ) the 
+    # although it is perfectly ok ( it seems ) to redeclare an array when
+    # one of the same name exists ( it doesn't seem to do anything ) the
     # desire is to only create one if it's needed, so to do this we use the
     # lenght of the array as a proxy for existence as bash has no way to  check fo
     # the existence of an empty array that I can find
@@ -248,7 +248,7 @@ function die_on_error(){
 if [ -d /etc/starphleet.d ]; then
   for env_file in /etc/starphleet.d/*
   do
-    source ${env_file}
+    test -f "${env_file}" && source "${env_file}"
   done
 fi
 [ -f "${HEADQUARTERS_SOURCE}" ] && source "${HEADQUARTERS_SOURCE}"


### PR DESCRIPTION
- The dir /etc/starphleet.d gets created on new installs.  However, if a
  file doesn't exist in that directory then the new code for
  starphleet.d runs with an error (no files found).  Scripts with set -e
  die on that.  All sorts of weird things happen