### PR TITLE
Bug: Do not deploy commented autodeploys in dev_mode

### DIFF
--- a/overlay/etc/init/starphleet_monitor_orders.conf
+++ b/overlay/etc/init/starphleet_monitor_orders.conf
@@ -213,16 +213,16 @@ script
             # Now that we are deploying - make sure we unset our reason
             unset DEPLOY_REASON
           fi
-          # If we are in dev mode then there is never a good enough reason in
-          # ${DEPLOY_REASON} that we'd want a container with a sha so we
-          # force the rest of the code to be skipped
-          continue
-         ############################################
-         # End Dev Mode
-         ############################################
         else
           #resynchronize to autodeploy repo, this is the primary case
           starphleet-git-synch "${SERVICE_GIT_URL}" "${LOCAL}" && DEPLOY_REASON="Updated service"
+        fi
+
+        # If we are in dev mode then there is never a good enough reason in
+        # ${DEPLOY_REASON} that we'd want a container with a sha so we
+        # force the rest of the code to be skipped
+        if dev_mode; then
+          continue
         fi
       fi
       #if there is any reason to start a container -- well, go to it

--- a/overlay/etc/init/starphleet_monitor_orders.conf
+++ b/overlay/etc/init/starphleet_monitor_orders.conf
@@ -217,13 +217,12 @@ script
           #resynchronize to autodeploy repo, this is the primary case
           starphleet-git-synch "${SERVICE_GIT_URL}" "${LOCAL}" && DEPLOY_REASON="Updated service"
         fi
-
-        # If we are in dev mode then there is never a good enough reason in
-        # ${DEPLOY_REASON} that we'd want a container with a sha so we
-        # force the rest of the code to be skipped
-        if dev_mode ; then
-          continue
-        fi
+      fi
+      # If we are in dev mode then there is never a good enough reason in
+      # ${DEPLOY_REASON} that we'd want a container with a sha so we
+      # force the rest of the code to be skipped
+      if dev_mode ; then
+        continue
       fi
       #if there is any reason to start a container -- well, go to it
       if [ -n "${DEPLOY_REASON}" ]; then

--- a/overlay/etc/init/starphleet_monitor_orders.conf
+++ b/overlay/etc/init/starphleet_monitor_orders.conf
@@ -221,7 +221,7 @@ script
         # If we are in dev mode then there is never a good enough reason in
         # ${DEPLOY_REASON} that we'd want a container with a sha so we
         # force the rest of the code to be skipped
-        if dev_mode; then
+        if dev_mode ; then
           continue
         fi
       fi


### PR DESCRIPTION
If the user comments out the 'autodeploy' line it creates a condition in which dev_mode does not respect the appropriate behavior and generates a broken container.