### PR TITLE
Allow orders to specify notification addresses

### DIFF
--- a/overlay/etc/init/starphleet_serve_order.post-start
+++ b/overlay/etc/init/starphleet_serve_order.post-start
@@ -33,6 +33,7 @@ else
     trace "${name}" "${PORT}" "${PUBLISH_PORT}" "/${order}" "${HTPASSWD}" "${LDAP}"
     if ! starphleet-publish "${name}" "/${order}" "${HEADQUARTERS_LOCAL}/${order}/orders" "${HTPASSWD}" "${LDAP}" ; then
       echo 'publish failed' > "${CURRENT_ORDERS}/${order}/.starphleetstatus"
+      mail_failure_log
       exit 1
     fi
     #record online, with the IP address of the container
@@ -46,12 +47,13 @@ else
     #we wait a small time for prior requests to flush out
     sleep ${STARPHLEET_DRAINSTOP_WAIT}
     starphleet-reaper "${name}" "${order}"
+    mail_success_log
     exit 0
   else
     #at this point the service has failed to properly start
     warn service failed to publish "/${order}"
     echo 'failed' > "${CURRENT_ORDERS}/${order}/.starphleetstatus"
-    mail_log
+    mail_failure_log
     exit 1
   fi
 fi

--- a/overlay/etc/init/starphleet_serve_order.post-start
+++ b/overlay/etc/init/starphleet_serve_order.post-start
@@ -33,7 +33,7 @@ else
     trace "${name}" "${PORT}" "${PUBLISH_PORT}" "/${order}" "${HTPASSWD}" "${LDAP}"
     if ! starphleet-publish "${name}" "/${order}" "${HEADQUARTERS_LOCAL}/${order}/orders" "${HTPASSWD}" "${LDAP}" ; then
       echo 'publish failed' > "${CURRENT_ORDERS}/${order}/.starphleetstatus"
-      mail_failure_log
+      failure_mail_log
       exit 1
     fi
     #record online, with the IP address of the container
@@ -47,13 +47,13 @@ else
     #we wait a small time for prior requests to flush out
     sleep ${STARPHLEET_DRAINSTOP_WAIT}
     starphleet-reaper "${name}" "${order}"
-    mail_success_log
+    success_mail_log
     exit 0
   else
     #at this point the service has failed to properly start
     warn service failed to publish "/${order}"
     echo 'failed' > "${CURRENT_ORDERS}/${order}/.starphleetstatus"
-    mail_failure_log
+    failure_mail_log
     exit 1
   fi
 fi

--- a/overlay/etc/init/starphleet_serve_order.start
+++ b/overlay/etc/init/starphleet_serve_order.start
@@ -5,8 +5,8 @@ info "starting ${name}"
 ORDER_LOCAL="${HEADQUARTERS_LOCAL}/${order}/git"
 run_orders "${HEADQUARTERS_LOCAL}/${order}/orders"
 if [ "${UNPUBLISHED}" == "1" ]; then
-  lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "2>&1 sleep 1000000" | logger -t "${order}" || mail_failure_log
+  lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "2>&1 sleep 1000000" | logger -t "${order}" || failure_mail_log
 else
-  lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "2>&1 setsid ~/start web" | logger -t "${order}" || mail_failure_log
+  lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "2>&1 setsid ~/start web" | logger -t "${order}" || failure_mail_log
 fi
 echo 'stopped' > "${CURRENT_ORDERS}/${order}/.starphleetstatus"

--- a/overlay/etc/init/starphleet_serve_order.start
+++ b/overlay/etc/init/starphleet_serve_order.start
@@ -5,8 +5,8 @@ info "starting ${name}"
 ORDER_LOCAL="${HEADQUARTERS_LOCAL}/${order}/git"
 run_orders "${HEADQUARTERS_LOCAL}/${order}/orders"
 if [ "${UNPUBLISHED}" == "1" ]; then
-  lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "2>&1 sleep 1000000" | logger -t "${order}" || mail_log
+  lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "2>&1 sleep 1000000" | logger -t "${order}" || mail_failure_log
 else
-  lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "2>&1 setsid ~/start web" | logger -t "${order}" || mail_log
+  lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "2>&1 setsid ~/start web" | logger -t "${order}" || mail_failure_log
 fi
 echo 'stopped' > "${CURRENT_ORDERS}/${order}/.starphleetstatus"

--- a/scripts/tools
+++ b/scripts/tools
@@ -87,14 +87,26 @@ function make_admiral() {
   info admiral created
 }
 
-function mail_log()
+function mail_failure_log()
 {
   if which mail > /dev/null; then
     ORDER_LOCAL="${HEADQUARTERS_LOCAL}/${order}/git"
     latest_AUTHOR "${ORDER_LOCAL}"
+    [ -n "${BUILD_NOTIFICATION_EMAIL_ADDRESSES}" ] && AUTHOR="${AUTHOR},${BUILD_NOTIFICATION_EMAIL_ADDRESSES}"
     cat /var/log/upstart/${UPSTART_JOB}-${name}.log \
     | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" \
     | mail -s "Starphleet Build Failure: ${name}" "${AUTHOR}"
+  fi
+}
+
+function mail_success_log()
+{
+  if which mail > /dev/null; then
+    if [ -n "${BUILD_NOTIFICATION_EMAIL_ADDRESSES}" ]; then
+      cat /var/log/upstart/${UPSTART_JOB}-${name}.log \
+      | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g" \
+      | mail -s "Starphleet Build Success: ${name}" "${BUILD_NOTIFICATION_EMAIL_ADDRESSES}"
+    fi
   fi
 }
 

--- a/scripts/tools
+++ b/scripts/tools
@@ -87,7 +87,7 @@ function make_admiral() {
   info admiral created
 }
 
-function mail_failure_log()
+function failure_mail_log()
 {
   if which mail > /dev/null; then
     ORDER_LOCAL="${HEADQUARTERS_LOCAL}/${order}/git"
@@ -99,7 +99,7 @@ function mail_failure_log()
   fi
 }
 
-function mail_success_log()
+function success_mail_log()
 {
   if which mail > /dev/null; then
     if [ -n "${BUILD_NOTIFICATION_EMAIL_ADDRESSES}" ]; then


### PR DESCRIPTION
- Allow orders to contain "BUILD_NOTIFICATION_EMAIL_ADDRESSES".  If
  specified the recipient list will receive all build and all failure
  notices in addition to the GIT owner
- Addresses are a comma separated list of email addresses