### PR TITLE
Bug: install packages before config changes

### DIFF
--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -25,6 +25,19 @@ declare -A EC2_DRIVES
 
 # Auto handle formatting/mounting of EC2 Drives
 ec2_mounts
+#
+#packages
+debconf-set-selections <<< "postfix postfix/mailname string '${SHIP}'"
+debconf-set-selections <<< "postfix postfix/main_mailer_type string 'Internet Site'"
+
+# Run Upgrade before before installing packages - which fixes this error
+# https://github.com/lxc/lxc/issues/247
+apt-get update -y
+export DEBIAN_FRONTEND=noninteractive
+apt-get dist-upgrade -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --force-yes
+
+apt-get -y install --force-yes $(< "${DIR}/packages")
+
 
 #put in the system overlay, gets all the files in place
 #for the starphleet jobs
@@ -70,18 +83,6 @@ dpkg-reconfigure -f noninteractive tzdata
 hostname "${SHIP}"
 echo "${SHIP}" > /etc/hostname
 echo "127.0.0.1 ${SHIP} localhost" > /etc/hosts
-
-#packages
-debconf-set-selections <<< "postfix postfix/mailname string '${SHIP}'"
-debconf-set-selections <<< "postfix postfix/main_mailer_type string 'Internet Site'"
-
-# Run Upgrade before before installing packages - which fixes this error
-# https://github.com/lxc/lxc/issues/247
-apt-get update -y
-export DEBIAN_FRONTEND=noninteractive
-apt-get dist-upgrade -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --force-yes
-
-apt-get -y install --force-yes $(< "${DIR}/packages")
 
 pushd ${STARPHLEET_ROOT:-/var/starphleet}/nginx
 set -e


### PR DESCRIPTION
- LXC subnet changes modify default system files which causes install to prompt
  for override.  I don't see a logical reason not to install the
  packages earlier in the install.  This fixes production installs and
  vmware now works again.  No prompts since we update the config after
  the package completes