### PR TITLE
Service failover

### DIFF
--- a/overlay/var/starphleet/nginx/nginx.conf
+++ b/overlay/var/starphleet/nginx/nginx.conf
@@ -37,6 +37,7 @@ http {
   auth_ldap_cache_size 1024;
   include beta_groups/*.conf;
   include acl_rules/*.conf;
+  include published/*.upstream;
 
   server {
     listen 80;

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -63,7 +63,7 @@ cat << EOF > "${UPSTREAM_CONF}"
 upstream ${order} {
   server localhost;
 EOF
-for failover_server in $(echo "${PHLEET}"); do
+for failover_server in "${PHLEET}"; do
   if [ -n "${STARPHLEET_THIS_SHIP}" ] && [ "${STARPHLEET_THIS_SHIP}" != "${failover_server}" ]; then
     echo "  server ${failover_server} backup;" >> "${UPSTREAM_CONF}"
   fi

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -22,8 +22,10 @@ public_url="/${order}"
 if [ "${public_url}" == "/" ]; then
   public_url=""
 fi
+#Failover confs
+FAILOVER_CONF="${NGINX_CONF}/published/${order}.conf"
 #mount this service over a path
-MOUNT_CONF="${NGINX_CONF}/published/${order}.conf"
+MOUNT_CONF="${NGINX_CONF}/published/${order}-local.conf"
 #Upstream conf
 UPSTREAM_CONF="${NGINX_CONF}/published/${order}.upstream"
 #mount this service over a port
@@ -70,9 +72,8 @@ cat << EOF >> "${UPSTREAM_CONF}"
 }
 EOF
 
-
 #basic publication at an url mount point
-cat << EOF > "${MOUNT_CONF}"
+cat << EOF > "${FAILOVER_CONF}"
 
 location ${public_url}/ {
   gzip on;
@@ -80,8 +81,34 @@ location ${public_url}/ {
   gzip_proxied any;
   gzip_comp_level 6;
   include ${NGINX_CONF}/cors.conf;
-  rewrite ${public_url}/(.*) /\$1 break;
+  rewrite ${public_url}/(.*) /${order}-local/\$1 break;
   proxy_pass http://${order};
+  proxy_next_upstream error http_502;
+  proxy_set_header X-Forwarded-Host \$host;
+  proxy_set_header X-Forwarded-Server \$host;
+  proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+  proxy_set_header X-Starphleet-Service-Name: ${order};
+  proxy_set_header Host \$http_host;
+  # WebSocket support (nginx 1.4)
+  proxy_http_version 1.1;
+  proxy_set_header Upgrade \$http_upgrade;
+  proxy_set_header Connection "upgrade";
+EOF
+#closing off the location
+echo '}' >> "${FAILOVER_CONF}"
+
+
+#basic publication at an url mount point
+cat << EOF > "${MOUNT_CONF}"
+
+location ${public_url}-local/ {
+  gzip on;
+  gzip_types *;
+  gzip_proxied any;
+  gzip_comp_level 6;
+  include ${NGINX_CONF}/cors.conf;
+  rewrite ${public_url}-local/(.*) /\$1 break;
+  proxy_pass http://${IP_ADDRESS}:${PORT};
   proxy_next_upstream error http_502;
   proxy_set_header X-Forwarded-Host \$host;
   proxy_set_header X-Forwarded-Server \$host;

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -109,7 +109,6 @@ location ${public_url}-local/ {
   include ${NGINX_CONF}/cors.conf;
   rewrite ${public_url}-local/(.*) /\$1 break;
   proxy_pass http://${IP_ADDRESS}:${PORT};
-  proxy_next_upstream error http_502;
   proxy_set_header X-Forwarded-Host \$host;
   proxy_set_header X-Forwarded-Server \$host;
   proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -83,7 +83,7 @@ location ${public_url}/ {
   include ${NGINX_CONF}/cors.conf;
   rewrite ${public_url}/(.*) /${order}-local/\$1 break;
   proxy_pass http://${order};
-  proxy_next_upstream error http_502;
+  proxy_next_upstream error http_502 http_503;
   proxy_set_header X-Forwarded-Host \$host;
   proxy_set_header X-Forwarded-Server \$host;
   proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -24,6 +24,8 @@ if [ "${public_url}" == "/" ]; then
 fi
 #mount this service over a path
 MOUNT_CONF="${NGINX_CONF}/published/${order}.conf"
+#Upstream conf
+UPSTREAM_CONF="${NGINX_CONF}/published/${order}.upstream"
 #mount this service over a port
 BARE_CONF="${NGINX_CONF}/published_bare/${order}.conf"
 #redirect your urls to lxc
@@ -51,6 +53,24 @@ mkdir -p "${NGINX_CONF}/named_servers"
 [ -f "${NGINX_CONF}/published/crt" ] || cp "${NGINX_CONF}/crt" "${NGINX_CONF}/published/crt"
 [ -f "${NGINX_CONF}/published/key" ] || cp "${NGINX_CONF}/key" "${NGINX_CONF}/published/key"
 
+# Build the upstream list for this service
+# The default behavior sends traffic only to this container.  If a 'PHLEET'
+# variable is set in conjunction with a per-machine setting of STARPHLEET_THIS_SHIP
+# we will proxy failed requests to other ships
+cat << EOF > "${UPSTREAM_CONF}"
+upstream ${order} {
+  server ${IP_ADDRESS}:${PORT};
+EOF
+for failover_server in $(echo "${PHLEET}"); do
+  if [ -n "${STARPHLEET_THIS_SHIP}" ] && [ "${STARPHLEET_THIS_SHIP}" != "${failover_server}" ]; then
+    echo "  server ${failover_server} backup;" >> "${UPSTREAM_CONF}"
+  fi
+done
+cat << EOF >> "${UPSTREAM_CONF}"
+}
+EOF
+
+
 #basic publication at an url mount point
 cat << EOF > "${MOUNT_CONF}"
 
@@ -61,7 +81,8 @@ location ${public_url}/ {
   gzip_comp_level 6;
   include ${NGINX_CONF}/cors.conf;
   rewrite ${public_url}/(.*) /\$1 break;
-  proxy_pass http://${IP_ADDRESS}:${PORT};
+  proxy_pass http://${order};
+  proxy_next_upstream error http_502;
   proxy_set_header X-Forwarded-Host \$host;
   proxy_set_header X-Forwarded-Server \$host;
   proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -61,7 +61,7 @@ mkdir -p "${NGINX_CONF}/named_servers"
 # we will proxy failed requests to other ships
 cat << EOF > "${UPSTREAM_CONF}"
 upstream ${order} {
-  server ${IP_ADDRESS}:${PORT};
+  server localhost;
 EOF
 for failover_server in $(echo "${PHLEET}"); do
   if [ -n "${STARPHLEET_THIS_SHIP}" ] && [ "${STARPHLEET_THIS_SHIP}" != "${failover_server}" ]; then

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -63,7 +63,7 @@ cat << EOF > "${UPSTREAM_CONF}"
 upstream ${order} {
   server localhost;
 EOF
-for failover_server in "${PHLEET}"; do
+for failover_server in ${PHLEET}; do
   if [ -n "${STARPHLEET_THIS_SHIP}" ] && [ "${STARPHLEET_THIS_SHIP}" != "${failover_server}" ]; then
     echo "  server ${failover_server} backup;" >> "${UPSTREAM_CONF}"
   fi


### PR DESCRIPTION
- Set a machine level or order level variable "PHLEET" with a list of failover servers
- Must set "STARPHLEET_THIS_SHIP" on a per-machine basis to enable the feature
- Tries all requests locally first, then falls back to "PHLEET" machines

The normal endpoint /[service] has been renamed to /[service]-local.  The default behavior does a rewrite to the local endpoint first, then on failure, tries the backup endpoints.
