### PR TITLE
Service failover take two

### DIFF
--- a/overlay/var/starphleet/nginx/nginx.conf
+++ b/overlay/var/starphleet/nginx/nginx.conf
@@ -32,6 +32,7 @@ http {
   proxy_cache_path "/var/cache/nginx" levels=1 keys_zone=primary_zone:15m;
 
   server_names_hash_max_size 4096;
+  server_names_hash_bucket_size 4096;
   include ldap_servers/*.conf;
   auth_ldap_cache_enabled on;
   auth_ldap_cache_expiration_time 28800000;

--- a/overlay/var/starphleet/nginx/nginx.conf
+++ b/overlay/var/starphleet/nginx/nginx.conf
@@ -6,7 +6,6 @@ daemon off;
 error_log  /dev/stdout;
 pid        /var/run/starphleet_nginx.pid;
 worker_rlimit_nofile 20000;
-server_names_hash_max_size 4096;
 
 events {
   worker_connections  10000;
@@ -32,6 +31,7 @@ http {
 
   proxy_cache_path "/var/cache/nginx" levels=1 keys_zone=primary_zone:15m;
 
+  server_names_hash_max_size 4096;
   include ldap_servers/*.conf;
   auth_ldap_cache_enabled on;
   auth_ldap_cache_expiration_time 28800000;

--- a/overlay/var/starphleet/nginx/nginx.conf
+++ b/overlay/var/starphleet/nginx/nginx.conf
@@ -37,6 +37,7 @@ http {
   auth_ldap_cache_size 1024;
   include beta_groups/*.conf;
   include acl_rules/*.conf;
+  include published/*.upstream;
 
   server {
     listen 80;
@@ -59,6 +60,8 @@ http {
     include published/*.conf;
 
   }
+
+  include published/*.server;
 
   include /etc/starphleet_nginx/*.conf;
 

--- a/overlay/var/starphleet/nginx/nginx.conf
+++ b/overlay/var/starphleet/nginx/nginx.conf
@@ -6,6 +6,7 @@ daemon off;
 error_log  /dev/stdout;
 pid        /var/run/starphleet_nginx.pid;
 worker_rlimit_nofile 20000;
+server_names_hash_max_size 4096;
 
 events {
   worker_connections  10000;

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -18,6 +18,8 @@ declare -A BETAS
 declare -A REDIRECT_TO
 run_orders "${orders_file}"
 
+STARPHLEET_HOSTNAME=${STARPHLEET_HOSTNAME:-starphleet.com}
+
 public_url="/${order}"
 if [ "${public_url}" == "/" ]; then
   public_url=""
@@ -110,7 +112,7 @@ EOF
 cat << EOF > "${SERVER_CONF}"
 
 server {
-  server_name ${order}.glgresearch.com;
+  server_name ${order}.${STARPHLEET_HOSTNAME};
   ssl_certificate      published/crt;
   ssl_certificate_key  published/key;
   listen 80;
@@ -130,7 +132,7 @@ server {
     proxy_set_header X-Forwarded-Server \$host;
     proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
     proxy_set_header X-Starphleet-Service-Name: ${order};
-    proxy_set_header Host ${order}.glgresearch.com;
+    proxy_set_header Host ${order}.${STARPHLEET_HOSTNAME};
     # WebSocket support (nginx 1.4)
     proxy_http_version 1.1;
     proxy_set_header Upgrade \$http_upgrade;

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -72,12 +72,18 @@ location ${public_url}/ {
   include ${NGINX_CONF}/cors.conf;
   rewrite ${public_url}/(.*) /\$1 break;
   proxy_pass http://${order};
+  proxy_next_upstream error http_502 http_503;
   proxy_set_header X-Forwarded-Host \$host;
   proxy_set_header X-Forwarded-Server \$host;
   proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
   proxy_set_header X-Starphleet-Service-Name: ${order};
   proxy_set_header Host ${order}.glgresearch.com;
   # WebSocket support (nginx 1.4)
+  proxy_http_version 1.1;
+  proxy_set_header Upgrade \$http_upgrade;
+  proxy_set_header Connection "upgrade";
+  more_set_headers 'X-Starphleet-Service: ${public_url}';
+  more_set_headers 'X-Starphleet-Container: ${container_name}';
 EOF
 
 #closing off the location

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -79,7 +79,7 @@ location ${public_url}/ {
   proxy_set_header X-Forwarded-Server \$host;
   proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
   proxy_set_header X-Starphleet-Service-Name: ${order};
-  proxy_set_header Host ${order}.glgresearch.com;
+  proxy_set_header Host ${order}.${STARPHLEET_HOSTNAME};
   # WebSocket support (nginx 1.4)
   proxy_http_version 1.1;
   proxy_set_header Upgrade \$http_upgrade;

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -22,8 +22,12 @@ public_url="/${order}"
 if [ "${public_url}" == "/" ]; then
   public_url=""
 fi
+#Failover confs
+SERVER_CONF="${NGINX_CONF}/published/${order}.server"
 #mount this service over a path
-MOUNT_CONF="${NGINX_CONF}/published/${order}.conf"
+MOUNT_CONF="${NGINX_CONF}/published/${order}-local.conf"
+#Upstream conf
+UPSTREAM_CONF="${NGINX_CONF}/published/${order}.upstream"
 #mount this service over a port
 BARE_CONF="${NGINX_CONF}/published_bare/${order}.conf"
 #redirect your urls to lxc
@@ -51,7 +55,13 @@ mkdir -p "${NGINX_CONF}/named_servers"
 [ -f "${NGINX_CONF}/published/crt" ] || cp "${NGINX_CONF}/crt" "${NGINX_CONF}/published/crt"
 [ -f "${NGINX_CONF}/published/key" ] || cp "${NGINX_CONF}/key" "${NGINX_CONF}/published/key"
 
-#basic publication at an url mount point
+# This breaks down as follows:
+#   - Create a location directive in the default settings of the server
+#     that points to upstream server(s) and sets the hostheader for the request
+#     to <service>.${PHLEET_HOSTNAME}  based on /<service>
+#   - The upstream server(s) will respect the host header (ex: <service>.${PHLEET_HOSTNAME})
+#   - The server directives point directly to the container without the /<service> endpoint attached
+
 cat << EOF > "${MOUNT_CONF}"
 
 location ${public_url}/ {
@@ -61,57 +71,108 @@ location ${public_url}/ {
   gzip_comp_level 6;
   include ${NGINX_CONF}/cors.conf;
   rewrite ${public_url}/(.*) /\$1 break;
-  proxy_pass http://${IP_ADDRESS}:${PORT};
+  proxy_pass http://${order};
   proxy_set_header X-Forwarded-Host \$host;
   proxy_set_header X-Forwarded-Server \$host;
   proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
   proxy_set_header X-Starphleet-Service-Name: ${order};
-  proxy_set_header Host \$http_host;
+  proxy_set_header Host ${order}.glgresearch.com;
   # WebSocket support (nginx 1.4)
-  proxy_http_version 1.1;
-  proxy_set_header Upgrade \$http_upgrade;
-  proxy_set_header Connection "upgrade";
-  more_set_headers 'X-Starphleet-Service: ${public_url}';
-  more_set_headers 'X-Starphleet-Container: ${container_name}';
+EOF
+
+#closing off the location
+echo '}' >> "${MOUNT_CONF}"
+
+# Build the upstream list for this service
+# The default behavior sends traffic only to this container.  If a 'PHLEET'
+# variable is set in conjunction with a per-machine setting of STARPHLEET_THIS_SHIP
+# we will proxy failed requests to other ships
+cat << EOF > "${UPSTREAM_CONF}"
+upstream ${order} {
+  server localhost;
+EOF
+for failover_server in ${PHLEET}; do
+  if [ -n "${STARPHLEET_THIS_SHIP}" ] && [ "${STARPHLEET_THIS_SHIP}" != "${failover_server}" ]; then
+    echo "  server ${failover_server} backup;" >> "${UPSTREAM_CONF}"
+  fi
+done
+cat << EOF >> "${UPSTREAM_CONF}"
+}
+EOF
+
+#basic publication at an url mount point
+cat << EOF > "${SERVER_CONF}"
+
+server {
+  server_name ${order}.glgresearch.com;
+  ssl_certificate      published/crt;
+  ssl_certificate_key  published/key;
+  listen 80;
+  listen 443 ssl spdy;
+
+  large_client_header_buffers 4 32k;
+
+
+  location / {
+    gzip on;
+    gzip_types *;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    include ${NGINX_CONF}/cors.conf;
+    proxy_pass http://${IP_ADDRESS}:${PORT};
+    proxy_set_header X-Forwarded-Host \$host;
+    proxy_set_header X-Forwarded-Server \$host;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    proxy_set_header X-Starphleet-Service-Name: ${order};
+    proxy_set_header Host ${order}.glgresearch.com;
+    # WebSocket support (nginx 1.4)
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade \$http_upgrade;
+    proxy_set_header Connection "upgrade";
+    more_set_headers 'X-Starphleet-Service: ${public_url}';
+    more_set_headers 'X-Starphleet-Container: ${container_name}';
 EOF
 # If the Starphleet EC2 Region is set - also output this header
 if [ ! -z "${STARPHLEET_EC2_REGION}" ]; then
-  echo "  more_set_headers 'X-Starphleet-Ship: ${STARPHLEET_EC2_REGION}';" >> "${MOUNT_CONF}"
+  echo "    more_set_headers 'X-Starphleet-Ship: ${STARPHLEET_EC2_REGION}';" >> "${SERVER_CONF}"
 fi
 if [[ "${htpasswd}" != '' && "${htpasswd}" != '-' ]]; then
   info password file enabled
-  echo "  auth_basic \"\";" >> "${MOUNT_CONF}"
-  echo "  auth_basic_user_file ${htpasswd};" >> "${MOUNT_CONF}"
-  echo "  proxy_set_header ${USER_IDENTITY_HEADER} \$remote_user;" >> "${MOUNT_CONF}"
-  echo "  add_header Set-Cookie ${USER_IDENTITY_COOKIE}=\$remote_user;" >> "${MOUNT_CONF}"
+  echo "    auth_basic \"\";" >> "${SERVER_CONF}"
+  echo "    auth_basic_user_file ${htpasswd};" >> "${SERVER_CONF}"
+  echo "    proxy_set_header ${USER_IDENTITY_HEADER} \$remote_user;" >> "${SERVER_CONF}"
+  echo "    add_header Set-Cookie ${USER_IDENTITY_COOKIE}=\$remote_user;" >> "${SERVER_CONF}"
 fi
 if [ ! -z "${DEVMODE_FORCE_AUTH}" ]; then
-  echo "  proxy_set_header ${USER_IDENTITY_HEADER} ${DEVMODE_FORCE_AUTH};" >> "${MOUNT_CONF}"
-  echo "  add_header Set-Cookie ${USER_IDENTITY_COOKIE}=${DEVMODE_FORCE_AUTH};" >> "${MOUNT_CONF}"
+  echo "    proxy_set_header ${USER_IDENTITY_HEADER} ${DEVMODE_FORCE_AUTH};" >> "${SERVER_CONF}"
+  echo "    add_header Set-Cookie ${USER_IDENTITY_COOKIE}=${DEVMODE_FORCE_AUTH};" >> "${SERVER_CONF}"
 fi
 if [[ "${ldap}" != '' && "${ldap}" != '-' ]]; then
   info LDAP enabled
-  echo "  auth_ldap \"Forbidden!\";" >> "${MOUNT_CONF}"
-  echo "  auth_ldap_servers $(cat ${ldap});" >> "${MOUNT_CONF}"
-  echo "  proxy_set_header ${USER_IDENTITY_HEADER} \$remote_user;" >> "${MOUNT_CONF}"
-  echo "  add_header Set-Cookie ${USER_IDENTITY_COOKIE}=\$remote_user;" >> "${MOUNT_CONF}"
+  echo "    auth_ldap \"Forbidden!\";" >> "${SERVER_CONF}"
+  echo "    auth_ldap_servers $(cat ${ldap});" >> "${SERVER_CONF}"
+  echo "    proxy_set_header ${USER_IDENTITY_HEADER} \$remote_user;" >> "${SERVER_CONF}"
+  echo "    add_header Set-Cookie ${USER_IDENTITY_COOKIE}=\$remote_user;" >> "${SERVER_CONF}"
 
   # don't want to ldap authenticate from other containers on the ship
   # see http://forum.nginx.org/read.php?2,242713,242742#msg-242742
   # note: this needs an auth_basic that alway fails and has the same name as auth_ldap
-  echo "  satisfy any;" >> "${MOUNT_CONF}"
-  echo "  allow 10.0.0.0/8;" >> "${MOUNT_CONF}"
+  echo "    satisfy any;" >> "${SERVER_CONF}"
+  echo "    allow 10.0.0.0/8;" >> "${SERVER_CONF}"
   # Future proof
-  echo "  allow 172.16.0.0/12;" >> "${MOUNT_CONF}"
+  echo "    allow 172.16.0.0/12;" >> "${SERVER_CONF}"
   # Allow no auth
-  echo "  allow 172.32.0.0/16;" >> "${MOUNT_CONF}"
-  echo "  allow 172.33.0.0/16;" >> "${MOUNT_CONF}"
+  echo "    allow 172.32.0.0/16;" >> "${SERVER_CONF}"
+  echo "    allow 172.33.0.0/16;" >> "${SERVER_CONF}"
 fi
 
-
-
 #closing off the location
-echo '}' >> "${MOUNT_CONF}"
+echo '  }' >> "${SERVER_CONF}"
+#closing off the server conf
+echo '}' >> "${SERVER_CONF}"
+
+
+
 
 info "published ${container_name}:${PORT} to ${public_url}"
 


### PR DESCRIPTION
- Set a machine level or order level variable "PHLEET" with a list of failover servers
- Must set "STARPHLEET_THIS_SHIP" on a per-machine basis to enable the feature
- Tries all requests locally first, then falls back to "PHLEET" machines

The normal endpoint /[service] always gets redirected to [service].[STARPHLEET_HOSTNAME]. This hostname is now setup as a server directive that points to the container.  Each service is setup as a server directive.
