### PR TITLE
Run starphleet-clean on pre-start

### DIFF
--- a/overlay/etc/init/starphleet.conf
+++ b/overlay/etc/init/starphleet.conf
@@ -5,6 +5,12 @@ stop on [!2345]
 
 respawn
 
+pre-start script
+  set +e
+  source `which tools`
+  starphleet-cleanup
+end script
+
 script
   source `which tools`
   ec2_mounts

--- a/scripts/starphleet-cleanup
+++ b/scripts/starphleet-cleanup
@@ -24,3 +24,6 @@ rm -rf /home/admiral/tmp 2> /dev/null
 test -d "${NGINX_CONF}/published" && rm -rf "${NGINX_CONF}/published"
 test -d "${NGINX_CONF}/published_bare" && rm -rf "${NGINX_CONF}/published_bare"
 test -d "${NGINX_CONF}/beta_groups" && rm -rf "${NGINX_CONF}/beta_groups"
+
+# Exit clean
+exit 0


### PR DESCRIPTION
- In devmode, vagrant halt doesn't always allow starphleet to shutdown
  cleanly.  Thus, files don't get cleaned up correctly. Run a cleanup
  before starting up starphleet as well