### PR TITLE
DNS Online/Offline support for new hupper

### DIFF
--- a/overlay/etc/init/starphleet_nginx_hupper.start
+++ b/overlay/etc/init/starphleet_nginx_hupper.start
@@ -86,6 +86,13 @@ do
       starphleet-expose "${name}" "${HEADQUARTERS_LOCAL}/${order}/orders"
     done
 
+    # Support NGINX DNS online/offline operations.  
+    if [ -f "${STARPHLEET_DNS_ONLINE_STATUS_FILE}" ] && [ ! -h "${NGINX_STATUS_CONFIG_SYMLINK}" ]; then
+      # Create the symlink
+      ln -s ${NGINX_STATUS_ENDPOINT_CONFIG} ${NGINX_STATUS_CONFIG_SYMLINK}
+
+    fi
+
     ######################
     # Validate Config / HUP
     ######################

--- a/overlay/etc/starphleet
+++ b/overlay/etc/starphleet
@@ -36,6 +36,7 @@ export USER_IDENTITY_COOKIE="starphleet_user"
 export NGINX_PUBLISHED_PATH="/var/starphleet/nginx/published"
 export NGINX_STATUS_CONFIG_SYMLINK="${NGINX_PUBLISHED_PATH}/starphleet_nginx_status.status"
 export NGINX_STATUS_ENDPOINT_CONFIG="/var/starphleet/nginx/status.conf"
+export STARPHLEET_DNS_ONLINE_STATUS_FILE="/tmp/.starphleet.online"
 # Declare drives we'd setup and where they should mount for starphleet install on EC2
 declare -A EC2_DRIVES
 EC2_DRIVES["/dev/xvdb"]="/var/lib/lxc"

--- a/scripts/starphleet-dns-offline
+++ b/scripts/starphleet-dns-offline
@@ -6,8 +6,7 @@
 die_on_error
 run_as_root_or_die
 
-# Remove the endpoint from nginx
-[ -h ${NGINX_STATUS_CONFIG_SYMLINK} ] && rm ${NGINX_STATUS_CONFIG_SYMLINK}
+[ -f "${STARPHLEET_DNS_ONLINE_STATUS_FILE}" ] && rm "${STARPHLEET_DNS_ONLINE_STATUS_FILE}"
 
 ## HUP NGinx
 starphleet-hup-nginx

--- a/scripts/starphleet-dns-online
+++ b/scripts/starphleet-dns-online
@@ -6,11 +6,7 @@
 die_on_error
 run_as_root_or_die
 
-# If the symlink already exists - punt
-[ -h ${NGINX_STATUS_CONFIG_SYMLINK} ] && exit 0
-
-# Create the symlink
-ln -s ${NGINX_STATUS_ENDPOINT_CONFIG} ${NGINX_STATUS_CONFIG_SYMLINK}
+touch "${STARPHLEET_DNS_ONLINE_STATUS_FILE}"
 
 ## HUP NGinx
 starphleet-hup-nginx


### PR DESCRIPTION
- The starphleet-dns-online/offline commands need to support the new
  concept of the hupper doing all-the-things for configuration nginx.