### PR TITLE
Remove build logs when a container is reaped

### DIFF
--- a/overlay/etc/init/starphleet_serve_order.post-stop
+++ b/overlay/etc/init/starphleet_serve_order.post-stop
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 source `which tools`
 
-starphleet-lxc-stop "${name}"
+# Pipe output to /dev/null so it doesn't log this stop and create
+# a new stale log
+starphleet-lxc-stop "${name}" > /dev/null
 if [ "${PROCESS}" == "respawn" ]; then
   # remove the last known good indicator so we don't re-use anything
   # if we've encountered a problems starting the container (hit the

--- a/scripts/starphleet-reaper
+++ b/scripts/starphleet-reaper
@@ -84,6 +84,9 @@ do
   starphleet-lxc-destroy "${name}" || true
   info "Removing status files"
   rm ${CURRENT_ORDERS}/${order}/.starphleetstatus.${name}* 2> /dev/null || true
+  info "Removing Logs"
+  rm /var/logs/upstart/starphleet_serve_order-${name}* 2> /dev/null || true
+  rm /var/logs/upstart/starphleet_orders_healthcheck-${name}* 2> /dev/null || true
   info "reaper has reaped ${name}"
 done
 

--- a/scripts/starphleet-reaper
+++ b/scripts/starphleet-reaper
@@ -83,10 +83,10 @@ do
   info "Destroying container ${name}"
   starphleet-lxc-destroy "${name}" || true
   info "Removing status files"
-  rm ${CURRENT_ORDERS}/${order}/.starphleetstatus.${name}* 2> /dev/null || true
-  info "Removing Logs"
-  rm /var/logs/upstart/starphleet_serve_order-${name}* 2> /dev/null || true
-  rm /var/logs/upstart/starphleet_orders_healthcheck-${name}* 2> /dev/null || true
+  rm ${CURRENT_ORDERS}/${order}/.starphleetstatus.${name}* || true
+  info "Removing Logs for ${name}"
+  rm /var/log/upstart/starphleet_serve_order-${name}* || true
+  rm /var/log/upstart/starphleet_orders_healthcheck-${name}* || true
   info "reaper has reaped ${name}"
 done
 

--- a/scripts/starphleet-reaper
+++ b/scripts/starphleet-reaper
@@ -82,7 +82,7 @@ do
   stop starphleet_serve_order name="${name}" || true
   info "Destroying container ${name}"
   starphleet-lxc-destroy "${name}" || true
-  info "Removing status files"
+  info "Removing status files for ${name}"
   rm ${CURRENT_ORDERS}/${order}/.starphleetstatus.${name}* || true
   info "Removing Logs for ${name}"
   rm /var/log/upstart/starphleet_serve_order-${name}* || true


### PR DESCRIPTION
- Successful reaps of a container imply a newer and working container is
  up and we would no longer need to reference the previous build logs.
  Thus, we are now going to reap the old logs