### PR TITLE
Make /var/data separate from /var/lib/lxc

### DIFF
--- a/overlay/etc/starphleet
+++ b/overlay/etc/starphleet
@@ -42,3 +42,4 @@ declare -A EC2_DRIVES
 EC2_DRIVES["/dev/xvdb"]="/var/lib/lxc"
 EC2_DRIVES["/dev/xvdc"]="/var/starphleet"
 EC2_DRIVES["/dev/xvdd"]="/var/log/biglogs"
+EC2_DRIVES["/dev/xvde"]="/var/lib/lxc/data"


### PR DESCRIPTION
- Allow making /var/data huge and also filling up /var/data won't impact
  the functionality of the machines