### PR TITLE
Need a force reap when called for a stop

### DIFF
--- a/overlay/etc/init/starphleet_serve_order.post-start
+++ b/overlay/etc/init/starphleet_serve_order.post-start
@@ -15,7 +15,7 @@ run_orders "${HEADQUARTERS_LOCAL}/${order}/orders"
 if [ "${UNPUBLISHED}" == "1" ]; then
   echo 'online' > "${STATUS_FILE}"
   starphleet-expose "${name}" "${HEADQUARTERS_LOCAL}/${order}/orders"
-  starphleet-reaper "${name}" "${order}"
+  starphleet-reaper "${name}" "${order}" --force
 else
   #status logging, here indicating the healthcheck is about to go
   echo 'checking' > "${STATUS_FILE}"

--- a/overlay/etc/init/starphleet_serve_order.pre-start
+++ b/overlay/etc/init/starphleet_serve_order.pre-start
@@ -11,7 +11,7 @@ run_orders "${HEADQUARTERS_LOCAL}/${order}/orders"
 #pre stop if the service demands it
 if [ "${STOP_BEFORE_AUTODEPLOY}" == "1" ]; then
   info stopping before autodeploy
-  starphleet-reaper "${name}" "${order}"
+  starphleet-reaper "${name}" "${order}" --force
 fi
 
 LAST_KNOWN_GOOD_CONTAINER=$(cat "${CURRENT_ORDERS}/${order}/.last_known_good_container" || true)


### PR DESCRIPTION
- Need to support new --force for orders with 'stop_before" since the
  normal reap condition now guards against reaping containers still
  running by default