### PR TITLE
Starphleet Forked Worker Support

### DIFF
--- a/overlay/etc/init/starphleet_serve_order.post-start
+++ b/overlay/etc/init/starphleet_serve_order.post-start
@@ -20,7 +20,6 @@ else
   #status logging, here indicating the healthcheck is about to go
   echo 'checking' > "${STATUS_FILE}"
   lxc-ls --fancy "${name}" | tail -1 | awk '{ print $3; }' > "${STATUS_FILE}.ip"
-  echo "${PORT}" > "${STATUS_FILE}.port"
 
   ######################
   # Healthchecks

--- a/overlay/etc/init/starphleet_serve_order.start
+++ b/overlay/etc/init/starphleet_serve_order.start
@@ -8,9 +8,16 @@ STATUS_FILE="${CURRENT_ORDERS}/${order}/.starphleetstatus.${name}"
 if [ "${UNPUBLISHED}" == "1" ]; then
   lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "2>&1 sleep 1000000" | logger -t "${order}" || mail_log
 else
+  # Take whatever port is set and make a list from there of worker ports
+  # Example:
+  #   WORKERS=3
+  #   PORT=3000
+  # Result:
+  #   PORT=3000 3001 3002
   PORT=$(seq -s " " ${PORT} $((${PORT}+(${WORKERS}-1))))
+  # Keep track of all the ports we are using
   echo "${PORT}" > "${STATUS_FILE}.port"
+  # Run a worker for each port
   parallel --ungroup "lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} PORT={} bash -c '2>&1 setsid ~/start web'" ::: ${PORT} | logger -t "${order}" || mail_log
-  echo "Stopped running"
 fi
 echo 'stopped' > "${STATUS_FILE}"

--- a/overlay/etc/init/starphleet_serve_order.start
+++ b/overlay/etc/init/starphleet_serve_order.start
@@ -8,10 +8,9 @@ STATUS_FILE="${CURRENT_ORDERS}/${order}/.starphleetstatus.${name}"
 if [ "${UNPUBLISHED}" == "1" ]; then
   lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "2>&1 sleep 1000000" | logger -t "${order}" || mail_log
 else
-  WORKERS=${WORKERS:-1}
-  PORT=${PORT:-3000}
   PORT=$(seq -s " " ${PORT} $((${PORT}+(${WORKERS}-1))))
-  parallel --ungroup "lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} -u PORT={} bash -c '2>&1 setsid ~/start web'" ::: ${PORT} | logger -t "${order}" || mail_log
   echo "${PORT}" > "${STATUS_FILE}.port"
+  parallel --ungroup "lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} PORT={} bash -c '2>&1 setsid ~/start web'" ::: ${PORT} | logger -t "${order}" || mail_log
+  echo "Stopped running"
 fi
 echo 'stopped' > "${STATUS_FILE}"

--- a/overlay/etc/init/starphleet_serve_order.start
+++ b/overlay/etc/init/starphleet_serve_order.start
@@ -11,7 +11,7 @@ else
   WORKERS=${WORKERS:-1}
   PORT=${PORT:-3000}
   PORT=$(seq -s " " ${PORT} $((${PORT}+(${WORKERS}-1))))
-  parallel --ungroup "echo lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} -u PORT={} bash -c '2>&1 setsid ~/start web'" ::: ${PORT} | logger -t "${order}" || mail_log
+  parallel --ungroup "lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} -u PORT={} bash -c '2>&1 setsid ~/start web'" ::: ${PORT} | logger -t "${order}" || mail_log
   echo "${PORT}" > "${STATUS_FILE}.port"
 fi
 echo 'stopped' > "${STATUS_FILE}"

--- a/overlay/etc/init/starphleet_serve_order.start
+++ b/overlay/etc/init/starphleet_serve_order.start
@@ -8,6 +8,10 @@ STATUS_FILE="${CURRENT_ORDERS}/${order}/.starphleetstatus.${name}"
 if [ "${UNPUBLISHED}" == "1" ]; then
   lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "2>&1 sleep 1000000" | logger -t "${order}" || mail_log
 else
-  lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "2>&1 setsid ~/start web" | logger -t "${order}" || mail_log
+  WORKERS=${WORKERS:-1}
+  PORT=${PORT:-3000}
+  PORT=$(seq -s " " ${PORT} $((${PORT}+(${WORKERS}-1))))
+  parallel --ungroup "echo lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} -u PORT={} bash -c '2>&1 setsid ~/start web'" ::: ${PORT} | logger -t "${order}" || mail_log
+  echo "${PORT}" > "${STATUS_FILE}.port"
 fi
 echo 'stopped' > "${STATUS_FILE}"

--- a/overlay/etc/starphleet
+++ b/overlay/etc/starphleet
@@ -1,6 +1,7 @@
 #configure starphleet here
 #a default port for the forgetful order
-export PORT=3001
+export PORT=${PORT:-3000}
+export WORKERS=${WORKERS:-1}
 export PUBLISH_PORT=0
 export LXC_ROOT="/var/lib/lxc"
 export STARPHLEET_SHARED_DATA="${LXC_ROOT}/data"

--- a/overlay/var/starphleet/nginx/nginx.conf
+++ b/overlay/var/starphleet/nginx/nginx.conf
@@ -37,6 +37,7 @@ http {
   auth_ldap_cache_size 1024;
   include beta_groups/*.conf;
   include acl_rules/*.conf;
+  include published/*.upstream;
 
   server {
     listen 80;

--- a/scripts/packages
+++ b/scripts/packages
@@ -23,3 +23,4 @@ ntp
 postfix
 rsync
 awscli
+parallel

--- a/scripts/starphleet-healthcheck
+++ b/scripts/starphleet-healthcheck
@@ -13,17 +13,21 @@ HEALTHCHECK_TIMEOUT=${HEALTHCHECK_TIMEOUT:-30}
 [ -f "${STATUS_FILE}.port" ] && CONTAINER_PORT=$(cat "${STATUS_FILE}.port")
 URL=${url:-/}
 
-if [ -z ${CONTAINER_IP} ] || [ -z ${CONTAINER_PORT} ]; then
+if [ -z "${CONTAINER_IP}" ] || [ -z "${CONTAINER_PORT}" ]; then
   error "Cannot find container ip address or port"
   exit 1
 fi
 
-TEST_GET="http://${CONTAINER_IP}:${CONTAINER_PORT}${URL}"
-TEST_COMMAND="curl -X GET --connect-timeout ${HEALTHCHECK_TIMEOUT} -o /dev/null -s -w %{response_code} ${TEST_GET}"
-RESULT=`${TEST_COMMAND}`
-if [ ${RESULT} == "200" ]; then
-  exit 0
-fi
+# If any of the workers are responding we have success.  NGINX will handle
+# killing off dead workers
+for PORT_TO_CHECK in ${CONTAINER_PORT}; do
+  TEST_GET="http://${CONTAINER_IP}:${PORT_TO_CHECK}${URL}"
+  TEST_COMMAND="curl -X GET --connect-timeout ${HEALTHCHECK_TIMEOUT} -o /dev/null -s -w %{response_code} ${TEST_GET}"
+  RESULT=`${TEST_COMMAND}`
+  if [ ${RESULT} == "200" ]; then
+    exit 0
+  fi
+done
 
 error Failed Healthcheck - ${TEST_GET}
 exit 1

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -54,10 +54,7 @@ mkdir -p "${NGINX_CONF}/named_servers"
 [ -f "${NGINX_CONF}/published/crt" ] || cp "${NGINX_CONF}/crt" "${NGINX_CONF}/published/crt"
 [ -f "${NGINX_CONF}/published/key" ] || cp "${NGINX_CONF}/key" "${NGINX_CONF}/published/key"
 
-# Build the upstream list for this service
-# The default behavior sends traffic only to this container.  If a 'PHLEET'
-# variable is set in conjunction with a per-machine setting of STARPHLEET_THIS_SHIP
-# we will proxy failed requests to other ships
+# Build an upstream config for each worker port exposed
 echo "upstream ${order} {" > "${UPSTREAM_CONF}"
 for WORKER_PORT in ${PORT}; do
   echo "  server ${IP_ADDRESS}:${WORKER_PORT};" >> "${UPSTREAM_CONF}"

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -31,6 +31,8 @@ REDIRECT_CONF="${NGINX_CONF}/published/${order}.redirect"
 #mount this service over a path
 PROXY_FOR_CONF="${NGINX_CONF}/proxy_for/${order}.conf"
 SERVER_NAMES_CONF="${NGINX_CONF}/named_servers/${order}.conf"
+# Upstream configs
+UPSTREAM_CONF="${NGINX_CONF}/published/${order}.upstream"
 
 IP_ADDRESS=$(cat "${CURRENT_ORDERS}/${order}/.starphleetstatus.${container_name}.ip")
 PORT=$(cat "${CURRENT_ORDERS}/${order}/.starphleetstatus.${container_name}.port")
@@ -52,6 +54,16 @@ mkdir -p "${NGINX_CONF}/named_servers"
 [ -f "${NGINX_CONF}/published/crt" ] || cp "${NGINX_CONF}/crt" "${NGINX_CONF}/published/crt"
 [ -f "${NGINX_CONF}/published/key" ] || cp "${NGINX_CONF}/key" "${NGINX_CONF}/published/key"
 
+# Build the upstream list for this service
+# The default behavior sends traffic only to this container.  If a 'PHLEET'
+# variable is set in conjunction with a per-machine setting of STARPHLEET_THIS_SHIP
+# we will proxy failed requests to other ships
+echo "upstream ${order} {" > "${UPSTREAM_CONF}"
+for WORKER_PORT in ${PORT}; do
+  echo "  server ${IP_ADDRESS}:${WORKER_PORT};" >> "${UPSTREAM_CONF}"
+done
+echo "}" > "${UPSTREAM_CONF}"
+
 #basic publication at an url mount point
 cat << EOF > "${MOUNT_CONF}"
 
@@ -62,7 +74,7 @@ location ${public_url}/ {
   gzip_comp_level 6;
   include ${NGINX_CONF}/cors.conf;
   rewrite ${public_url}/(.*) /\$1 break;
-  proxy_pass http://${IP_ADDRESS}:${PORT};
+  proxy_pass http://${order};
   proxy_set_header X-Forwarded-Host \$host;
   proxy_set_header X-Forwarded-Server \$host;
   proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -62,7 +62,7 @@ echo "upstream ${order} {" > "${UPSTREAM_CONF}"
 for WORKER_PORT in ${PORT}; do
   echo "  server ${IP_ADDRESS}:${WORKER_PORT};" >> "${UPSTREAM_CONF}"
 done
-echo "}" > "${UPSTREAM_CONF}"
+echo "}" >> "${UPSTREAM_CONF}"
 
 #basic publication at an url mount point
 cat << EOF > "${MOUNT_CONF}"


### PR DESCRIPTION
If a user specifies "WORKERS" in the orders file - spawn multiple copies of their application on unique ports.  Configure NGINX to balance the load to all their workers using upstreams.
