### PR TITLE
Support App Beta Cookies

### DIFF
--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -61,8 +61,9 @@ location ${public_url}/ {
   gzip_proxied any;
   gzip_comp_level 6;
   include ${NGINX_CONF}/cors.conf;
-  if (\$cookie_beta_${order}) {
-    rewrite ${public_url}/(.*) /\$cookie_beta_${order}/\$1 last;
+  if (\$http_cookie ~ "beta_${order}=(.*?)(;|$)") {
+    set \$sendto \$1;
+    rewrite ${public_url}/(.*) /\$sendto/\$1 last;
   }
   rewrite ${public_url}/(.*) /\$1 break;
   proxy_pass http://${IP_ADDRESS}:${PORT};
@@ -180,7 +181,6 @@ do
   echo " rewrite ^ ${REDIRECT_TO[$redirected]}\$uri permanent;" >> "${REDIRECT_CONF}"
   echo " break;" >> "${REDIRECT_CONF}"
   echo "}" >> "${REDIRECT_CONF}"
-
 done
 
 

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -61,6 +61,9 @@ location ${public_url}/ {
   gzip_proxied any;
   gzip_comp_level 6;
   include ${NGINX_CONF}/cors.conf;
+  if (\$cookie_beta_${order}) {
+    rewrite ${public_url}/(.*) /\$cookie_beta_${order}/\$1 last;
+  }
   rewrite ${public_url}/(.*) /\$1 break;
   proxy_pass http://${IP_ADDRESS}:${PORT};
   proxy_set_header X-Forwarded-Host \$host;


### PR DESCRIPTION
Allow the redirect for a service to be set by a cookie.  For instance:

- Make a cookie named beta_serviceName
- Set value to betaName

User will silently get redirected from /serviceName to /betaName

This implementation may seem counter intuitive.  It works around NGINX not supporting hyphens in the $cookie variable inside rewrite rules.  The $cookie variable with hyphens does work within an `if` condition.  More details here:

http://bit.ly/1UQuC67