### PR TITLE
Support Restart of NGINX in Hupper

### DIFF
--- a/overlay/etc/cron.daily/restart_nginx
+++ b/overlay/etc/cron.daily/restart_nginx
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/bin/starphleet-restart-nginx

--- a/overlay/etc/init/starphleet_nginx_hupper.start
+++ b/overlay/etc/init/starphleet_nginx_hupper.start
@@ -100,6 +100,7 @@ do
       # the config is good, let's get nginx running
       if [ -f "${STARPHLEET_RESTART_NGINX_HUP_TURD}" ]; then
         restart starphleet_nginx || start starphleet_nginx
+        rm "${STARPHLEET_RESTART_NGINX_HUP_TURD}"
       else
         reload starphleet_nginx || start starphleet_nginx
       fi

--- a/overlay/etc/init/starphleet_nginx_hupper.start
+++ b/overlay/etc/init/starphleet_nginx_hupper.start
@@ -98,7 +98,11 @@ do
 
     if [ -z "${ERROR}" ] && ${STARPHLEET_ROOT}/nginx/nginx -p "${NGINX_CONF}" -c nginx.conf -t; then
       # the config is good, let's get nginx running
-      reload starphleet_nginx || start starphleet_nginx
+      if [ -f "${STARPHLEET_RESTART_NGINX_HUP_TURD}" ]; then
+        restart starphleet_nginx || start starphleet_nginx
+      else
+        reload starphleet_nginx || start starphleet_nginx
+      fi
     else
       #we have a bad configuration, we'll need to do something about that
       warn "nginx configuration fails validity test, will not restart or apply configuration changes"

--- a/overlay/etc/init/starphleet_nginx_hupper.start
+++ b/overlay/etc/init/starphleet_nginx_hupper.start
@@ -86,11 +86,10 @@ do
       starphleet-expose "${name}" "${HEADQUARTERS_LOCAL}/${order}/orders"
     done
 
-    # Support NGINX DNS online/offline operations.  
+    # Support NGINX DNS online/offline operations.
     if [ -f "${STARPHLEET_DNS_ONLINE_STATUS_FILE}" ] && [ ! -h "${NGINX_STATUS_CONFIG_SYMLINK}" ]; then
       # Create the symlink
       ln -s ${NGINX_STATUS_ENDPOINT_CONFIG} ${NGINX_STATUS_CONFIG_SYMLINK}
-
     fi
 
     ######################

--- a/overlay/etc/starphleet
+++ b/overlay/etc/starphleet
@@ -23,7 +23,10 @@ export NGINX_CONF="${STARPHLEET_ROOT}/nginx"
 export BUILDPACKS="${STARPHLEET_ROOT}/buildpacks"
 export ADMIRAL="admiral"
 export ADMIRAL_HOME="/home/admiral"
+# If this file exist the hupper will regen the nginx configs and hup nginx
 export STARPHLEET_NGINX_HUP_TURD="/var/run/starphleet_hup_turd"
+# If this file exist the hupper will 'restart' nginx when done instead of hup
+export STARPHLEET_RESTART_NGINX_HUP_TURD="/var/run/starphleet_restart_hup_turd"
 export MAX_OPEN_FILES="4096"
 if [ "${TERM}" == "unknown" ]; then
   export TERM="xterm-256color"

--- a/scripts/starphleet-restart-nginx
+++ b/scripts/starphleet-restart-nginx
@@ -1,0 +1,10 @@
+#!/usr/bin/env starphleet-launcher
+### Usage:
+###    starphleet-restart-nginx
+###
+### Requests that the hupper hup or start nginx as appropriate
+die_on_error
+run_as_root_or_die
+
+touch "${STARPHLEET_RESTART_NGINX_HUP_TURD}"
+/usr/bin/starphleet-hup-nginx

--- a/scripts/starphleet-restart-nginx
+++ b/scripts/starphleet-restart-nginx
@@ -2,7 +2,7 @@
 ### Usage:
 ###    starphleet-restart-nginx
 ###
-### Requests that the hupper hup or start nginx as appropriate
+### Requests that the hupper restart or start nginx as appropriate
 die_on_error
 run_as_root_or_die
 


### PR DESCRIPTION
The main NGINX process on the host OS will hold open workers for websockets.  If the websockets never disconnect the nginx processes are "leaked" until all websockets close.  Over time, this can creep towards the max number of NGINX threads nginx will start.  This patch adds the ability to trigger a safe NGINX restart (using the starphleet-nginx-hupper).  It also adds a cron job to run the restart once per day.