### PR TITLE
Publish Command

### DIFF
--- a/overlay/etc/init/starphleet_monitor_orders.start
+++ b/overlay/etc/init/starphleet_monitor_orders.start
@@ -55,14 +55,27 @@ do
   unset DEPLOY_REASON
   unset PUBLISH_FROM
   run_orders "${order}"
-  ##############################
+  ###################################
   # Support for 'publish' command
-  ##############################
-  # Touch a status file in current orders to tell the hupper to create a config
-  # for this endpoint also
+  ###################################
+  # The publish command sets a variable called "PUBLISH_FROM" with the the value
+  # being the argument passed to the command.  The value is intended to be
+  # the endpoint we want to publish at a new endpoint.  Below, if PUBLISH_FROM
+  # is set after running the orders AND the endpoint we want to alias does indeed
+  # exist, we will touch a status file resembling ".publish_$location".
+  # The location is basically tells the endpoint to mount itself at 'location' also.
+  #
+  # For example:
+  #   if -f ./current_orders/example1/.publish_example2; then
+  #       /example1 will also publish to /example2
+  #
+  # See: starphleet_nginx_hupper.start for more
   if [ -n "${PUBLISH_FROM}" ] && [ -d "${CURRENT_ORDERS}${PUBLISH_FROM}" ]; then
-    warn "Publish Detected: ${CURRENT_ORDERS}${PUBLISH_FROM}/.publish_${ORDER}"
-    touch "${CURRENT_ORDERS}${PUBLISH_FROM}/.publish_${ORDER}"
+    if [ ! -f "${CURRENT_ORDERS}${PUBLISH_FROM}/.publish_${ORDER}" ]; then
+      warn "Publish Detected: ${CURRENT_ORDERS}${PUBLISH_FROM}/.publish_${ORDER}"
+      touch "${CURRENT_ORDERS}${PUBLISH_FROM}/.publish_${ORDER}"
+      starphleet-hup-nginx
+    fi
     continue
   fi
   [ "${ORDERS_DIFF}" != "NONE" ] && DEPLOY_REASON="${ORDERS_DIFF}"

--- a/overlay/etc/init/starphleet_monitor_orders.start
+++ b/overlay/etc/init/starphleet_monitor_orders.start
@@ -26,7 +26,7 @@ do
   #from the order files in the headquarters
   CURRENT_ORDER="${CURRENT_ORDERS}/${ORDER}"
   mkdir -p "${CURRENT_ORDER}"
-  #use git to determing if the orders have changed since the last publish
+  #use git to determine if the orders have changed since the last publish
   if [ -f "${CURRENT_ORDER}/.orders_sha" ]; then
     DEPLOYED_ORDERS_SHA=$(cat "${CURRENT_ORDER}/.orders_sha")
     get_VERSION_DIFF ${HEADQUARTERS_LOCAL} ${ORDERS_SHA} ${DEPLOYED_ORDERS_SHA} $(dirname "${order}")
@@ -52,8 +52,19 @@ do
   #this lets folks get creative in orders files as needed
   unset SERVICE_GIT_URL
   unset UNPUBLISHED
-  run_orders "${order}"
   unset DEPLOY_REASON
+  unset PUBLISH_FROM
+  run_orders "${order}"
+  ##############################
+  # Support for 'publish' command
+  ##############################
+  # Touch a status file in current orders to tell the hupper to create a config
+  # for this endpoint also
+  if [ -n "${PUBLISH_FROM}" ] && [ -d "${CURRENT_ORDERS}${PUBLISH_FROM}" ]; then
+    warn "Publish Detected: ${CURRENT_ORDERS}${PUBLISH_FROM}/.publish_${ORDER}"
+    touch "${CURRENT_ORDERS}${PUBLISH_FROM}/.publish_${ORDER}"
+    continue
+  fi
   [ "${ORDERS_DIFF}" != "NONE" ] && DEPLOY_REASON="${ORDERS_DIFF}"
   #check if this publish port is a duplicate, halting the install of this
   #order if so, first one wins

--- a/overlay/etc/init/starphleet_nginx_hupper.start
+++ b/overlay/etc/init/starphleet_nginx_hupper.start
@@ -79,6 +79,21 @@ do
         fi
       fi
 
+      # If the above publish worked it should be safe to respect publish commands
+      for publish_file in $(find "${CURRENT_ORDERS}/${order}/".publish_* 2> /dev/null); do
+        NAME_ONLY=$(basename "${publish_file}" | sed -e 's|.publish_||')
+        # We need to make sure this publish isn't stale so we double check that
+        # the command is still valid in the orders file
+        if [ -f "${HEADQUARTERS_LOCAL}/${NAME_ONLY}/orders" ] &&
+           [ -n $(cat ${HEADQUARTERS_LOCAL}/${NAME_ONLY}/orders | grep publish | grep "${NAME_ONLY}") ]; then
+          warn "Publishing ${order} to ${NAME_ONLY}"
+          starphleet-publish "${name}" "${order}" "${HEADQUARTERS_LOCAL}/${order}/orders" "${HTPASSWD}" "${LDAP}" "${NAME_ONLY}"
+        else
+          warn "Stale Publish Command: ${publish_file}"
+          rm "${publish_file}"
+        fi
+      done
+
       # Keep track of the last good container as a fallback
       echo "${name}" > "${CURRENT_ORDERS}/${order}/.last_known_good_container"
 

--- a/overlay/etc/init/starphleet_nginx_hupper.start
+++ b/overlay/etc/init/starphleet_nginx_hupper.start
@@ -79,20 +79,25 @@ do
         fi
       fi
 
-      # If the above publish worked it should be safe to respect publish commands
+      ###################################
+      # Support for 'publish' command
+      ###################################
+      # If the above starphleet-publish worked and if we have any 'publish' files
+      # we need to also publish the nginx configs for our publish files.  This
+      # should be safe at this point since the above completed its health checks.
       for publish_file in $(find "${CURRENT_ORDERS}/${order}/".publish_* 2> /dev/null); do
         # Purge last run
         unset CHECK
-        unset NAME_ONLY
+        unset PUBLISH_DESTINATION
 
-        NAME_ONLY=$(basename "${publish_file}" | sed -e 's|.publish_||')
-        CHECK=$(cat ${HEADQUARTERS_LOCAL}/${NAME_ONLY}/orders | grep publish | grep "${order}")
-        # We need to make sure this publish isn't stale so we double check that
-        # the command is still valid in the orders file
-        if [ -f "${HEADQUARTERS_LOCAL}/${NAME_ONLY}/orders" ] &&
-           [ -n "${CHECK}" ]; then
-          warn "Publishing ${order} to ${NAME_ONLY}"
-          starphleet-publish "${name}" "${order}" "${HEADQUARTERS_LOCAL}/${order}/orders" "${HTPASSWD}" "${LDAP}" "${NAME_ONLY}"
+        # Extract the publish destination off the file name
+        PUBLISH_DESTINATION=$(basename "${publish_file}" | sed -e 's|.publish_||')
+        # Double check that the publish file isn't stale by checking the original
+        # orders for the command
+        [ -f "${HEADQUARTERS_LOCAL}/${PUBLISH_DESTINATION}/orders" ] && CHECK=$(cat ${HEADQUARTERS_LOCAL}/${PUBLISH_DESTINATION}/orders | grep publish | grep "${order}")
+        if [ -n "${CHECK}" ]; then
+          warn "Publishing ${order} to ${PUBLISH_DESTINATION}"
+          starphleet-publish "${name}" "${order}" "${HEADQUARTERS_LOCAL}/${order}/orders" "${HTPASSWD}" "${LDAP}" "${PUBLISH_DESTINATION}"
         else
           warn "Stale Publish Command: ${publish_file}"
           rm "${publish_file}"

--- a/overlay/etc/init/starphleet_nginx_hupper.start
+++ b/overlay/etc/init/starphleet_nginx_hupper.start
@@ -81,11 +81,16 @@ do
 
       # If the above publish worked it should be safe to respect publish commands
       for publish_file in $(find "${CURRENT_ORDERS}/${order}/".publish_* 2> /dev/null); do
+        # Purge last run
+        unset CHECK
+        unset NAME_ONLY
+
         NAME_ONLY=$(basename "${publish_file}" | sed -e 's|.publish_||')
+        CHECK=$(cat ${HEADQUARTERS_LOCAL}/${NAME_ONLY}/orders | grep publish | grep "${order}")
         # We need to make sure this publish isn't stale so we double check that
         # the command is still valid in the orders file
         if [ -f "${HEADQUARTERS_LOCAL}/${NAME_ONLY}/orders" ] &&
-           [ -n $(cat ${HEADQUARTERS_LOCAL}/${NAME_ONLY}/orders | grep publish | grep "${NAME_ONLY}") ]; then
+           [ -n "${CHECK}" ]; then
           warn "Publishing ${order} to ${NAME_ONLY}"
           starphleet-publish "${name}" "${order}" "${HEADQUARTERS_LOCAL}/${order}/orders" "${HTPASSWD}" "${LDAP}" "${NAME_ONLY}"
         else

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -1,6 +1,6 @@
 #!/usr/bin/env starphleet-launcher
 ### Usage:
-###    starphleet-publish <container_name> <order> <orders_file> <htpasswd> <ldap>
+###    starphleet-publish <container_name> <order> <orders_file> <htpasswd> <ldap> [<publish_path>]
 ### --help
 ###
 ### Publish HTTP traffic from the container out to the ship
@@ -18,10 +18,17 @@ declare -A BETAS
 declare -A REDIRECT_TO
 run_orders "${orders_file}"
 
+ORIGINAL_ORDER_NAME="${order}"
+
+if [ -n "${publish_path}" ]; then
+  order="${publish_path}"
+fi
+
 public_url="/${order}"
 if [ "${public_url}" == "/" ]; then
   public_url=""
 fi
+
 #mount this service over a path
 MOUNT_CONF="${NGINX_CONF}/published/${order}.conf"
 MOUNT_CACHED_CONF="${NGINX_CONF}/published/${order}_cached.conf"
@@ -33,8 +40,8 @@ REDIRECT_CONF="${NGINX_CONF}/published/${order}.redirect"
 PROXY_FOR_CONF="${NGINX_CONF}/proxy_for/${order}.conf"
 SERVER_NAMES_CONF="${NGINX_CONF}/named_servers/${order}.conf"
 
-IP_ADDRESS=$(cat "${CURRENT_ORDERS}/${order}/.starphleetstatus.${container_name}.ip")
-PORT=$(cat "${CURRENT_ORDERS}/${order}/.starphleetstatus.${container_name}.port")
+IP_ADDRESS=$(cat "${CURRENT_ORDERS}/${ORIGINAL_ORDER_NAME}/.starphleetstatus.${container_name}.ip")
+PORT=$(cat "${CURRENT_ORDERS}/${ORIGINAL_ORDER_NAME}/.starphleetstatus.${container_name}.port")
 
 info publishing to ${IP_ADDRESS}
 
@@ -166,7 +173,6 @@ else
   rm -f "${BARE_CONF}"
 fi
 
-echo "" > "${REDIRECT_CONF}"
 #redirect a DNS entry to the lxc url
 if [[ "${REDIRECT}" != '' && "${REDIRECT}" != '-' && "${REDIRECTTO}" != '' ]]; then
   info "redirect set for ${REDIRECT}"

--- a/scripts/tools
+++ b/scripts/tools
@@ -182,6 +182,10 @@ function run_orders()
     LOG_TO_STDERR=1
   }
 
+  publish () {
+    PUBLISH_FROM="${1}"
+  }
+
   source "${1}" || true
 }
 


### PR DESCRIPTION
Support for the publish command.  The publish command allows us to deploy a single instance of an app but 'publish' that app at multiple locations.  For instance this endpoint is deployed:

   /example1

In the orders file for /example2 and /example3 put "publish /example1".  

Starphleet will deploy /example1 once and create configs for /example2 and /example3 that point directly to the container of /example1