### PR TITLE
Respect port if set

### DIFF
--- a/overlay/etc/starphleet
+++ b/overlay/etc/starphleet
@@ -1,6 +1,6 @@
 #configure starphleet here
 #a default port for the forgetful order
-export PORT=3001
+export PORT=${PORT:-3001}
 export PUBLISH_PORT=0
 export LXC_ROOT="/var/lib/lxc"
 export STARPHLEET_SHARED_DATA="${LXC_ROOT}/data"


### PR DESCRIPTION
- Buildpacks have the port variable overwritten from the setting in the
  orders file.  This change will respect the orders if the variable is
  set but still fallback to having a default