### PR TITLE
Allow local machine envs to override the HQ

### DIFF
--- a/scripts/tools
+++ b/scripts/tools
@@ -351,6 +351,7 @@ function die_on_error(){
 
 # environment set up each time we ask for tools
 [ -f "/etc/starphleet" ] && source "/etc/starphleet"
+[ -f "${HEADQUARTERS_ENV}" ] && source "${HEADQUARTERS_ENV}"
 if [ -d /etc/starphleet.d ]; then
   for env_file in /etc/starphleet.d/*
   do
@@ -358,5 +359,4 @@ if [ -d /etc/starphleet.d ]; then
   done
 fi
 [ -f "${HEADQUARTERS_SOURCE}" ] && source "${HEADQUARTERS_SOURCE}"
-[ -f "${HEADQUARTERS_ENV}" ] && source "${HEADQUARTERS_ENV}"
 :


### PR DESCRIPTION
Allow a machine-level environment override to be primary over a global HQ.  That allows the refinement of configurations to go from:

Global -> Machine -> Orders