### PR TITLE
Bug that kills VMWare Fusion

### DIFF
--- a/overlay/etc/starphleet
+++ b/overlay/etc/starphleet
@@ -54,11 +54,11 @@ EC2_DRIVES["/dev/xvde"]="/var/lib/lxc/data"
 # htpasswd|ldap|public|jwt
 export SECURITY_MODE="htpasswd"
 # LDAP Needs
-export LDAP_SERVER=""
+unset LDAP_SERVER
 # JWT Needs
-export JWT_SECRET=""
-export JWT_AUTH_SITE=""
-export JWT_COOKIE_DOMAIN=""
-export JWT_ROLES=""
+unset JWT_SECRET
+unset JWT_AUTH_SITE
+unset JWT_COOKIE_DOMAIN
+unset JWT_ROLES
 # HTPASSWD Needs
-export HTPASSWD=""
+unset HTPASSWD

--- a/scripts/starphleet-devmode-update-local-ip
+++ b/scripts/starphleet-devmode-update-local-ip
@@ -23,4 +23,4 @@ ifconfig -a \
   | grep inet \
   | grep -v 127.0 \
   | awk '{print $2}' \
-  | tail -n 1 > "${HOME}/starphleet_dev/data/.localhostip"
+  | head -n 1 > "${HOME}/starphleet_dev/data/.localhostip"

--- a/vmware
+++ b/vmware
@@ -17,6 +17,15 @@ STARPHLEET_PRIVATE_KEY_FILE="${HOME}/.ssh/starphleet"
 STARPHLEET_PUBLIC_KEY_FILE="${HOME}/.ssh/starphleet.pub"
 
 # *********************
+# Fix Promiscuious mode crash
+#
+# Bug Fix
+#   See:  https://github.com/coreos/coreos-vagrant/issues/123
+# *********************
+
+sudo touch '/Library/Preferences/VMware Fusion/promiscAuthorized'
+
+# *********************
 # Helpers
 # *********************
 


### PR DESCRIPTION
- Grab First iface ip address for passing host info in local mode
- Unset default security modes instead of setting to empty
- Bug kills VMWare Fusion

Promisc mode for sniffers will kill the entire virtual machine.

Hopefully this fixes issue for mac users:

https://github.com/coreos/coreos-vagrant/issues/123