### PR TITLE
should it be needed, support for a root level jwt cookie so apps can

### DIFF
--- a/overlay/var/starphleet/nginx/lua/jwt_cookie.lua
+++ b/overlay/var/starphleet/nginx/lua/jwt_cookie.lua
@@ -7,6 +7,7 @@ if jwt_obj and jwt_obj["verified"] then
   local jwt = require "resty.jwt"
   local jwt_secret = ngx.var.jwt_secret
   local jwt_cookie_domain = ngx.var.jwt_cookie_domain
+  local jwt_global_cookie = ngx.var.jwt_global_cookie
   local token_duration = ngx.var.jwt_expiration
   local payload = jwt_obj["payload"]
   local leeway = ctx.leeway
@@ -20,6 +21,10 @@ if jwt_obj and jwt_obj["verified"] then
     payload["exp"] = exp
     local jwt_cookie = jwt:sign(jwt_secret, { payload=payload, header=jwt_obj.header } )
     local cookie_domain = not jwt_cookie_domain and '' or '; Domain=' .. jwt_cookie_domain
-    ngx.header['Set-Cookie'] = "jwt=" .. jwt_cookie .. cookie_domain .. "; Path=" .. service_public_url .. "; Expires=" .. ngx.cookie_time(ngx.time() + token_duration + leeway)
+    if jwt_global_cookie == "true" then
+      ngx.header['Set-Cookie'] = "jwt=" .. jwt_cookie .. cookie_domain .. "; Path=/; Expires=" .. ngx.cookie_time(ngx.time() + token_duration + leeway)
+    else
+      ngx.header['Set-Cookie'] = "jwt=" .. jwt_cookie .. cookie_domain .. "; Path=" .. service_public_url .. "; Expires=" .. ngx.cookie_time(ngx.time() + token_duration + leeway)
+    end
   end
 end

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -87,6 +87,9 @@ if [ "${SECURITY_MODE}" = 'jwt' ] ; then
   # have a max age this is 7 days worth of seconds
   echo "  set \$jwt_token_max_age ${JWT_TOKEN_MAX_AGE:-604800};" >> "${MOUNT_CONF}"
   echo "  set \$jwt_auth_site ${JWT_AUTH_SITE};" >> "${MOUNT_CONF}"
+  if [ -n "${JWT_GLOBAL_COOKIE}" -a "${JWT_GLOBAL_COOKIE}" != "false" ]; then
+    echo "  set \$jwt_global_cookie true;" >> "${MOUNT_CONF}"
+  fi
   echo "  set \$jwt_cookie_domain ${JWT_COOKIE_DOMAIN};" >> "${MOUNT_CONF}"
   echo "  set \$public_url ${public_url};" >> "${MOUNT_CONF}"
   # default expiration of 3600 seconds


### PR DESCRIPTION
share a login. NOTE! this will require that apps have explicitly
different values for the JWT_SECRET if they wish to not accidentally
share login info.