### PR TITLE
Devmode overhaul

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,8 @@ VAGRANT_MEMSIZE = ENV['STARPHLEET_VAGRANT_MEMSIZE'] || '8192'
 SHIP_NAME = 'ship'
 
 $base_provision_script = <<SCRIPT
-sudo bash -c "$(curl -s https://raw.githubusercontent.com/wballard/starphleet/master/webinstall)"
+# sudo bash -c "$(curl -s https://raw.githubusercontent.com/wballard/starphleet/master/webinstall)"
+# sudo ./starphleet/vmware_hgfs_fix.sh
 # sudo cp /starphleet/scripts/starphleet-launcher /usr/bin;
 # sudo /starphleet/scripts/starphleet-install;
 sudo apt-get install -y nfs-kernel-server
@@ -24,16 +25,6 @@ system("
 
 Vagrant::Config.run do |config|
   config.vm.provision :shell, :inline => $base_provision_script
-  system('
-    SCP="scp -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null"
-    SSH="ssh -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null"
-    ${SSH} "vagrant@ship.local" "sudo mkdir -p /var/starphleet/private_keys"
-    ${SSH} "vagrant@ship.local" "sudo chmod 777 /var/starphleet/private_keys"
-    ${SCP} "${STARPHLEET_PRIVATE_KEY}" "vagrant@ship.local:/var/starphleet/private_keys"
-    ${SSH} "vagrant@ship.local" "sudo chmod 600 /var/starphleet/private_keys"
-    ${SSH} "vagrant@ship.local" "sudo chmod 600 /var/starphleet/private_keys/*"
-    ${SSH} "vagrant@ship.local" "sudo chown root:root /var/starphleet/private_keys/*"
-  ')
 end
 
 
@@ -52,10 +43,20 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
     # if Dir.exists? 'private_keys' and Dir.exists? 'public_keys' and File.exists? 'headquarters'
     #   next
     # end
+  end
 
-    if not (ENV['STARPHLEET_HEADQUARTERS'] or ENV['STARPHLEET_PUBLIC_KEY'] or ENV['STARPHLEET_PRIVATE_KEY'])
-      raise 'Please export STARPHLEET_HEADQUARTERS, STARPHLEET_PUBLIC_KEY, STARPHLEET_PRIVATE_KEY before continuing'
-    end
+  config.trigger.after :vmware_fusion, :stdout => true, :force => true do
+    system('
+      echo here
+      # SCP="scp -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null"
+      # SSH="ssh -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null"
+      # ${SSH} "vagrant@ship.local" "sudo mkdir -p /var/starphleet/private_keys"
+      # ${SSH} "vagrant@ship.local" "sudo chmod 777 /var/starphleet/private_keys"
+      # ${SCP} "${STARPHLEET_PRIVATE_KEY}" "vagrant@ship.local:/var/starphleet/private_keys"
+      # ${SSH} "vagrant@ship.local" "sudo chmod 600 /var/starphleet/private_keys"
+      # ${SSH} "vagrant@ship.local" "sudo chmod 600 /var/starphleet/private_keys/*"
+      # ${SSH} "vagrant@ship.local" "sudo chown root:root /var/starphleet/private_keys/*"
+    ')
   end
 
   config.hostmanager.enabled = true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,12 +54,19 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
     end
   end
 
+  config.trigger.before :halt, :stdout => true, :force => true do
+    system('
+    sudo umount "${HOME}/starphleet_dev"
+    sudo umount "${HOME}/starphleet_data"
+    ')
+  end
+
   config.trigger.after :up, :stdout => true, :force => true do
     system('
     mkdir -p "${HOME}/starphleet_dev"
     mkdir -p "${HOME}/starphleet_data"
-    sudo mount -o resvport ship.glgresearch.com:/var/starphleet/headquarters "${HOME}/starphleet_dev"
-    sudo mount -o resvport ship.glgresearch.com:/var/lib/lxc/data "${HOME}/starphleet_data"
+    sudo mount -o resvport,intr ship.glgresearch.com:/var/starphleet/headquarters "${HOME}/starphleet_dev"
+    sudo mount -o resvport,intr ship.glgresearch.com:/var/lib/lxc/data "${HOME}/starphleet_data"
     [ -f ./scripts/starphleet-devmode-update-local-ip ] && ./scripts/starphleet-devmode-update-local-ip
     touch .provisioned
     ')

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 require 'fileutils'
 
 VAGRANT_MEMSIZE = ENV['STARPHLEET_VAGRANT_MEMSIZE'] || '8192'
-SHIP_NAME = 'ship'
+SHIP_NAME = [ENV['STARPHLEET_SHIP_NAME'] || 'ship', 'ship.local']
 
 $base_provision_script = <<SCRIPT
 cd /
@@ -73,8 +73,8 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
     system('
     mkdir -p "${HOME}/starphleet_dev"
     mkdir -p "${HOME}/starphleet_data"
-    sudo mount -o resvport,soft,intr ship.glgresearch.com:/var/starphleet/headquarters "${HOME}/starphleet_dev"
-    sudo mount -o resvport,soft,intr ship.glgresearch.com:/var/lib/lxc/data "${HOME}/starphleet_data"
+    sudo mount -o resvport,soft,intr ' + SHIP_NAME + ':/var/starphleet/headquarters "${HOME}/starphleet_dev"
+    sudo mount -o resvport,soft,intr ' + SHIP_NAME + ':/var/lib/lxc/data "${HOME}/starphleet_data"
     [ -f ./scripts/starphleet-devmode-update-local-ip ] && ./scripts/starphleet-devmode-update-local-ip
     touch .provisioned
     ')
@@ -82,14 +82,14 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
 
   config.hostmanager.enabled = true
   config.hostmanager.manage_host = true
-  config.hostmanager.aliases = [ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME, 'ship.local', 'ship.glgresearch.com']
+  config.hostmanager.aliases = SHIP_NAME
 
-  config.vm.hostname = ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME
+  config.vm.hostname = SHIP_NAME
 
   config.vm.provider :vmware_fusion do |f, override|
     override.vm.box = ENV['BOX_NAME'] || 'trusty-vmware'
     override.vm.box_url = "https://s3.amazonaws.com/glg_starphleet/trusty-14.04-amd64-vmwarefusion.box"
-    f.vmx["displayName"] = ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME
+    f.vmx["displayName"] = SHIP_NAME
     f.vmx["memsize"] = VAGRANT_MEMSIZE
   end
 
@@ -109,7 +109,7 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
 
   config.vm.provider :parallels do |f, override|
     override.vm.box = ENV['BOX_NAME'] || 'parallels/ubuntu-14.04'
-    f.name = ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME
+    f.name = SHIP_NAME
     f.customize ["set", :id, "--memsize", VAGRANT_MEMSIZE]
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -92,6 +92,7 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
 
   config.vm.provider :virtualbox do |f, override|
     override.vm.box = ENV['BOX_NAME'] || 'trusty-virtualbox'
+    override.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
     f.customize ["modifyvm", :id, "--memory", VAGRANT_MEMSIZE]
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,27 +7,13 @@ VAGRANT_MEMSIZE = ENV['STARPHLEET_VAGRANT_MEMSIZE'] || '8192'
 SHIP_NAME = 'ship'
 
 $base_provision_script = <<SCRIPT
-# XXX: RFC - Should starphleet delete the working directory of a developer?
-# I do not think starphleet should be destructive inherantly and should
-# error on caution.  The upstream scripts can ask the user if they want
-# to remove the dev dir.
-# test -d /hosthome/starphleet_dev/ && rm -rf /hosthome/starphleet_dev/;
-
-sudo cp /starphleet/scripts/starphleet-launcher /usr/bin;
-sudo /starphleet/scripts/starphleet-install;
+sudo bash -c "$(curl -s https://raw.githubusercontent.com/wballard/starphleet/master/webinstall)"
+# sudo cp /starphleet/scripts/starphleet-launcher /usr/bin;
+# sudo /starphleet/scripts/starphleet-install;
+sudo apt-get install -y nfs-kernel-server
+echo "/var/starphleet/headquarters *(rw,sync,all_squash,no_subtree_check,anonuid=0,anongid=0)" > /tmp/exports
+sudo mv /tmp/exports /etc
 $([ -n "#{ENV['STARPHLEET_HEADQUARTERS']}" ] && starphleet-headquarters #{ENV['STARPHLEET_HEADQUARTERS']}) || true;
-SCRIPT
-
-# This install of starphleet updates the kernel.  These patches must be run
-# at the end of the starphleet-install - these settings are only applicable
-# to
-$fix_vmware_tools_script = <<SCRIPT
-echo linux-image-3.13.0-24-generic hold | dpkg --set-selections
-echo linux-image-generic hold | dpkg --set-selections
-[ ! -f /tmp/patched ] && touch /tmp/patched || exit 0
-/starphleet/vmware_hgfs_fix.sh;
-sed -i.bak 's/answer AUTO_KMODS_ENABLED_ANSWER no/answer AUTO_KMODS_ENABLED_ANSWER yes/g' /etc/vmware-tools/locations;
-sed -i.bak 's/answer AUTO_KMODS_ENABLED no/answer AUTO_KMODS_ENABLED yes/g' /etc/vmware-tools/locations;
 SCRIPT
 
 system("
@@ -36,9 +22,18 @@ system("
   fi
 ")
 
-
 Vagrant::Config.run do |config|
   config.vm.provision :shell, :inline => $base_provision_script
+  system('
+    SCP="scp -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null"
+    SSH="ssh -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null"
+    ${SSH} "vagrant@ship.local" "sudo mkdir -p /var/starphleet/private_keys"
+    ${SSH} "vagrant@ship.local" "sudo chmod 777 /var/starphleet/private_keys"
+    ${SCP} "${STARPHLEET_PRIVATE_KEY}" "vagrant@ship.local:/var/starphleet/private_keys"
+    ${SSH} "vagrant@ship.local" "sudo chmod 600 /var/starphleet/private_keys"
+    ${SSH} "vagrant@ship.local" "sudo chmod 600 /var/starphleet/private_keys/*"
+    ${SSH} "vagrant@ship.local" "sudo chown root:root /var/starphleet/private_keys/*"
+  ')
 end
 
 
@@ -54,28 +49,13 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
 
   config.trigger.before :up, :stdout => true, :force => true do
     # If the machine is already provisioned - Don't do it again
-    if Dir.exists? 'private_keys' and Dir.exists? 'public_keys' and File.exists? 'headquarters'
-      next
-    end
+    # if Dir.exists? 'private_keys' and Dir.exists? 'public_keys' and File.exists? 'headquarters'
+    #   next
+    # end
 
     if not (ENV['STARPHLEET_HEADQUARTERS'] or ENV['STARPHLEET_PUBLIC_KEY'] or ENV['STARPHLEET_PRIVATE_KEY'])
       raise 'Please export STARPHLEET_HEADQUARTERS, STARPHLEET_PUBLIC_KEY, STARPHLEET_PRIVATE_KEY before continuing'
     end
-
-    FileUtils.mkdir 'private_keys' unless Dir.exists? 'private_keys'
-    FileUtils.mkdir 'public_keys' unless Dir.exists? 'public_keys'
-
-    FileUtils.cp ENV['STARPHLEET_PRIVATE_KEY'], 'private_keys'
-    FileUtils.cp ENV['STARPHLEET_PUBLIC_KEY'], 'public_keys'
-    File.open('headquarters', 'w') do |f|
-      f.write ENV['STARPHLEET_HEADQUARTERS']
-    end
-  end
-
-  config.trigger.after :destroy, :stdout => true, :force => true do
-    FileUtils.rm_rf 'private_keys'
-    FileUtils.rm_rf 'public_keys'
-    FileUtils.rm_rf 'headquarters'
   end
 
   config.hostmanager.enabled = true
@@ -83,21 +63,18 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
   config.hostmanager.aliases = [ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME, 'ship.local', 'ship.glgresearch.com']
 
   config.vm.hostname = ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME
-  config.vm.synced_folder ".", "/starphleet"
-  config.vm.synced_folder "~", "/hosthome"
+  # config.vm.synced_folder ".", "/starphleet"
+  # config.vm.synced_folder "~", "/hosthome"
 
   config.vm.provider :vmware_fusion do |f, override|
-    # override.vm.network "public_network"
     override.vm.box = ENV['BOX_NAME'] || 'trusty-vmware'
     override.vm.box_url = "https://s3.amazonaws.com/glg_starphleet/trusty-14.04-amd64-vmwarefusion.box"
     f.vmx["displayName"] = ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME
     f.vmx["memsize"] = VAGRANT_MEMSIZE
-    config.vm.provision :shell, :inline => $fix_vmware_tools_script
   end
 
   config.vm.provider :virtualbox do |f, override|
     override.vm.box = ENV['BOX_NAME'] || 'trusty-virtualbox'
-    #this box_url is totally hosed
     f.customize ["modifyvm", :id, "--memory", VAGRANT_MEMSIZE]
   end
 
@@ -105,7 +82,6 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
     override.vm.box = ENV['BOX_NAME'] || 'parallels/ubuntu-14.04'
     f.name = ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME
     f.customize ["set", :id, "--memsize", VAGRANT_MEMSIZE]
-    # This fixes an issue on OSX with parallels, when vagrant.pkg is still mounted
-    config.vm.synced_folder "./", "/vagrant", id: "some_id"
+    # config.vm.synced_folder "./", "/vagrant", id: "some_id"
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
   config.hostmanager.aliases = [ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME, 'ship.local', 'ship.glgresearch.com']
 
   config.vm.hostname = ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME
-  # config.vm.synced_folder ".", "/starphleet"
+  config.vm.synced_folder ".", "/starphleet"
   # config.vm.synced_folder "~", "/hosthome"
 
   config.vm.provider :vmware_fusion do |f, override|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,10 +8,11 @@ SHIP_NAME = 'ship'
 
 $base_provision_script = <<SCRIPT
 cd /
-sudo rsync -rav /vagrant/ /starphleet/
+# sudo rsync -rav --exclude=".vagrant" /vagrant/ /starphleet/
 sudo sudo cp /starphleet/scripts/starphleet-launcher /usr/bin
 sudo /starphleet/scripts/starphleet-install
-sudo /starphleet/vmware_hgfs_fix.sh
+echo "answer AUTO_KMODS_ENABLED yes" | sudo tee -a /etc/vmware-tools/locations
+# sudo /starphleet/vmware_hgfs_fix.sh
 sudo apt-get install -y nfs-kernel-server
 # Install private keys
 sudo mkdir -p /var/starphleet/private_keys

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 require 'fileutils'
 
 VAGRANT_MEMSIZE = ENV['STARPHLEET_VAGRANT_MEMSIZE'] || '8192'
-SHIP_NAME = [ENV['STARPHLEET_SHIP_NAME'] || 'ship', 'ship.local']
+SHIP_NAME = ENV['STARPHLEET_SHIP_NAME'] || 'ship.local'
 
 $base_provision_script = <<SCRIPT
 cd /
@@ -82,7 +82,7 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
 
   config.hostmanager.enabled = true
   config.hostmanager.manage_host = true
-  config.hostmanager.aliases = SHIP_NAME
+  # config.hostmanager.aliases = SHIP_NAME
 
   config.vm.hostname = SHIP_NAME
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,8 +8,8 @@ SHIP_NAME = 'ship'
 
 $base_provision_script = <<SCRIPT
 cd /
-# sudo bash -c "$(curl -s https://raw.githubusercontent.com/wballard/starphleet/master/webinstall)"
-# sudo ./starphleet/vmware_hgfs_fix.sh
+sudo bash -c "$(curl -s https://raw.githubusercontent.com/wballard/starphleet/master/webinstall)"
+sudo ./starphleet/vmware_hgfs_fix.sh
 sudo apt-get install -y nfs-kernel-server
 # Install private keys
 sudo mkdir -p /var/starphleet/private_keys

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,7 @@ require 'fileutils'
 
 VAGRANT_MEMSIZE = ENV['STARPHLEET_VAGRANT_MEMSIZE'] || '8192'
 SHIP_NAME = ENV['STARPHLEET_SHIP_NAME'] || 'ship.local'
+SHIP_HOSTNAME = SHIP_NAME.split('.')[0]
 
 $base_provision_script = <<SCRIPT
 cd /
@@ -82,14 +83,14 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
 
   config.hostmanager.enabled = true
   config.hostmanager.manage_host = true
-  # config.hostmanager.aliases = SHIP_NAME
+  config.hostmanager.aliases = [ SHIP_NAME, 'ship.local', SHIP_HOSTNAME ]
 
-  config.vm.hostname = SHIP_NAME
+  config.vm.hostname = SHIP_HOSTNAME
 
   config.vm.provider :vmware_fusion do |f, override|
     override.vm.box = ENV['BOX_NAME'] || 'trusty-vmware'
     override.vm.box_url = "https://s3.amazonaws.com/glg_starphleet/trusty-14.04-amd64-vmwarefusion.box"
-    f.vmx["displayName"] = SHIP_NAME
+    f.vmx["displayName"] = SHIP_HOSTNAME
     f.vmx["memsize"] = VAGRANT_MEMSIZE
   end
 
@@ -109,7 +110,7 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
 
   config.vm.provider :parallels do |f, override|
     override.vm.box = ENV['BOX_NAME'] || 'parallels/ubuntu-14.04'
-    f.name = SHIP_NAME
+    f.name = SHIP_HOSTNAME
     f.customize ["set", :id, "--memsize", VAGRANT_MEMSIZE]
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,8 +8,10 @@ SHIP_NAME = 'ship'
 
 $base_provision_script = <<SCRIPT
 cd /
-sudo bash -c "$(curl -s https://raw.githubusercontent.com/wballard/starphleet/master/webinstall)"
-sudo ./starphleet/vmware_hgfs_fix.sh
+sudo rsync -rav /vagrant/ /starphleet/
+sudo sudo cp /starphleet/scripts/starphleet-launcher /usr/bin
+sudo /starphleet/scripts/starphleet-install
+sudo /starphleet/vmware_hgfs_fix.sh
 sudo apt-get install -y nfs-kernel-server
 # Install private keys
 sudo mkdir -p /var/starphleet/private_keys

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,7 +46,10 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
     # if Dir.exists? 'private_keys' and Dir.exists? 'public_keys' and File.exists? 'headquarters'
     #   next
     # end
-    if not File.exists? './provisioned' and not (ENV['STARPHLEET_HEADQUARTERS'] or ENV['STARPHLEET_PUBLIC_KEY'] or ENV['STARPHLEET_PRIVATE_KEY'])
+    if File.file?('./.provisioned')
+      next
+    end
+    if not (ENV['STARPHLEET_HEADQUARTERS'] or ENV['STARPHLEET_PUBLIC_KEY'] or ENV['STARPHLEET_PRIVATE_KEY'])
       raise 'Please export STARPHLEET_HEADQUARTERS, STARPHLEET_PUBLIC_KEY, STARPHLEET_PRIVATE_KEY before continuing'
     end
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,7 @@ echo "/var/starphleet/headquarters *(rw,sync,all_squash,no_subtree_check,anonuid
 echo "/var/lib/lxc/data *(rw,sync,all_squash,no_subtree_check,anonuid=0,anongid=0)" >> /tmp/exports
 sudo mv /tmp/exports /etc
 sudo /etc/init.d/nfs-kernel-server restart
-$[ -n "#{ENV['STARPHLEET_HEADQUARTERS']}" ] && starphleet-headquarters #{ENV['STARPHLEET_HEADQUARTERS']} || true;
+[ -n "#{ENV['STARPHLEET_HEADQUARTERS']}" ] && starphleet-headquarters #{ENV['STARPHLEET_HEADQUARTERS']} || true;
 SCRIPT
 
 Vagrant::Config.run do |config|
@@ -45,10 +45,6 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
   end
 
   config.trigger.before :up, :stdout => true, :force => true do
-    # If the machine is already provisioned - Don't do it again
-    # if Dir.exists? 'private_keys' and Dir.exists? 'public_keys' and File.exists? 'headquarters'
-    #   next
-    # end
     if File.file?('./.provisioned')
       next
     end
@@ -80,8 +76,6 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
   config.hostmanager.aliases = [ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME, 'ship.local', 'ship.glgresearch.com']
 
   config.vm.hostname = ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME
-  # config.vm.synced_folder ".", "/starphleet"
-  # config.vm.synced_folder "~", "/hosthome"
 
   config.vm.provider :vmware_fusion do |f, override|
     override.vm.box = ENV['BOX_NAME'] || 'trusty-vmware'
@@ -100,6 +94,5 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
     override.vm.box = ENV['BOX_NAME'] || 'parallels/ubuntu-14.04'
     f.name = ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME
     f.customize ["set", :id, "--memsize", VAGRANT_MEMSIZE]
-    # config.vm.synced_folder "./", "/vagrant", id: "some_id"
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,7 +51,7 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
     if File.file?('./.provisioned')
       next
     end
-    if not (ENV['STARPHLEET_HEADQUARTERS'] or ENV['STARPHLEET_PUBLIC_KEY'] or ENV['STARPHLEET_PRIVATE_KEY'])
+    if not (ENV['STARPHLEET_HEADQUARTERS'] or ENV['STARPHLEET_PRIVATE_KEY'])
       raise 'Please export STARPHLEET_HEADQUARTERS, STARPHLEET_PUBLIC_KEY, STARPHLEET_PRIVATE_KEY before continuing'
     end
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,6 @@
 
 require 'fileutils'
 
-VAGRANT_CPUS = ENV['STARPHLEET_VAGRANT_CPUS'] || `expr $(sysctl -n hw.physicalcpu) / 2`
 VAGRANT_MEMSIZE = ENV['STARPHLEET_VAGRANT_MEMSIZE'] || '8192'
 SHIP_NAME = ENV['STARPHLEET_SHIP_NAME'] || 'ship.local'
 SHIP_HOSTNAME = SHIP_NAME.split('.')[0]
@@ -99,7 +98,6 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
     override.vm.box = ENV['BOX_NAME'] || 'trusty-virtualbox'
     override.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
     f.customize ["modifyvm", :id, "--memory", VAGRANT_MEMSIZE]
-    f.customize ["modifyvm", :id, "--cpus", VAGRANT_CPUS]
     config.vm.network "private_network", :type => 'dhcp', :adapter => 2
     config.hostmanager.ip_resolver = proc do |machine|
       result = ""

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,11 +8,11 @@ SHIP_NAME = 'ship'
 
 $base_provision_script = <<SCRIPT
 cd /
-# sudo rsync -rav --exclude=".vagrant" /vagrant/ /starphleet/
+sudo rsync -rav --exclude=".vagrant" /vagrant/ /starphleet/
 sudo sudo cp /starphleet/scripts/starphleet-launcher /usr/bin
 sudo /starphleet/scripts/starphleet-install
 echo "answer AUTO_KMODS_ENABLED yes" | sudo tee -a /etc/vmware-tools/locations
-# sudo /starphleet/vmware_hgfs_fix.sh
+sudo /starphleet/vmware_hgfs_fix.sh
 sudo apt-get install -y nfs-kernel-server
 # Install private keys
 sudo mkdir -p /var/starphleet/private_keys
@@ -26,7 +26,7 @@ echo "/var/starphleet/headquarters *(rw,sync,all_squash,no_subtree_check,anonuid
 echo "/var/lib/lxc/data *(rw,sync,all_squash,no_subtree_check,anonuid=0,anongid=0)" >> /tmp/exports
 sudo mv /tmp/exports /etc
 sudo /etc/init.d/nfs-kernel-server restart
-$([ -n "#{ENV['STARPHLEET_HEADQUARTERS']}" ] && starphleet-headquarters #{ENV['STARPHLEET_HEADQUARTERS']}) || true;
+$[ -n "#{ENV['STARPHLEET_HEADQUARTERS']}" ] && starphleet-headquarters #{ENV['STARPHLEET_HEADQUARTERS']} || true;
 SCRIPT
 
 Vagrant::Config.run do |config|
@@ -80,7 +80,7 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
   config.hostmanager.aliases = [ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME, 'ship.local', 'ship.glgresearch.com']
 
   config.vm.hostname = ENV['STARPHLEET_SHIP_NAME'] || SHIP_NAME
-  config.vm.synced_folder ".", "/starphleet"
+  # config.vm.synced_folder ".", "/starphleet"
   # config.vm.synced_folder "~", "/hosthome"
 
   config.vm.provider :vmware_fusion do |f, override|

--- a/overlay/etc/init/starphleet_monitor_headquarters.start
+++ b/overlay/etc/init/starphleet_monitor_headquarters.start
@@ -16,11 +16,6 @@ do
       service postfix reload || true
       starphleet-hup-nginx
     fi
-  else
-    warn "**"
-    warn You have no headquarters, add one with
-    warn starphleet-headquarters giturl
-    warn "**"
   fi
   # we'll wait a bit, and fall through allowing our respawn
   # to start us up again

--- a/overlay/etc/init/starphleet_monitor_orders.conf
+++ b/overlay/etc/init/starphleet_monitor_orders.conf
@@ -4,10 +4,7 @@ start on started starphleet
 stop on stopping starphleet
 
 respawn
-respawn limit 10 30
 
 script
   /etc/init/starphleet_monitor_orders.start
 end script
-
-post-stop exec sleep 5

--- a/overlay/etc/init/starphleet_monitor_orders.start
+++ b/overlay/etc/init/starphleet_monitor_orders.start
@@ -84,104 +84,56 @@ do
     continue
   fi
   [ "${ORDERS_DIFF}" != "NONE" ] && DEPLOY_REASON="${ORDERS_DIFF}"
-  #check if this publish port is a duplicate, halting the install of this
-  #order if so, first one wins
-  if [ "${PUBLISH_PORT}" != "0" ]; then
-    warn "${ORDER}" is requesting a host port "${PUBLISH_PORT}"
-    if [ -n "${PUBLISH_PORTS["${PUBLISH_PORT}"]}" ]; then
-      error ${ORDER} attempted to duplicate port ${PUBLISH_PORT}
-      echo ${ORDER} attempted to duplicate port ${PUBLISH_PORT} | mail -s 'Headquarters Error' "${AUTHOR}"
-      #clear this guard to prevent a deploy
-      SERVICE_GIT_URL=""
-    fi
-    PUBLISH_PORTS["${PUBLISH_PORT}"]="1"
-  fi
 
   #if there is a service repo, pull and synch it
   if [ -n "${SERVICE_GIT_URL}" ]; then
+    # The directory we store our local git copy
     LOCAL="${HEADQUARTERS_LOCAL}/${ORDER}/git"
-    #if there is new code in the remote for a service -- or if the orders have
-    #changed, it is time to start
+    # Sync Only Once In Devmode and All The Time If Devmode Disabled
+    (unique_mode && [ -d "${LOCAL}" ]) || (starphleet-git-synch "${SERVICE_GIT_URL}" "${LOCAL}" && DEPLOY_REASON="Updated service")
+    # The name of the service container
+    SERVICE_NAME="${ORDER}"
+    # The 'LAST_RUN_FILE' is created each run for a container.  We use this files
+    # modified time to determine if anything 'new' has been created/changed
+    # since our last deployment of a container
+    LAST_RUN_FILE="/tmp/.${SERVICE_NAME}-starphleet_last_run"
     ############################################
     # Modified Dev Mode
     ############################################
-    if dev_mode ; then
-      warn Dev Mode Detected
-      SERVICE_NAME=$(echo "${ORDER}")
-      #
-      # VMWARE Bug:  Large Git Repos puke when checking out to a shared folder
-      #              (does not happen to every user or every time)
-      #
-      # We've adjusted and made the first (and only the first) pass at building
-      # a container set all the things up that are necessary for the starphleet-dev
-      # directory on the HOST OS.
-      #
-      # The first container build
-      #   - Grabs the git repo to a tmp dir (/home/admiral/tmp/<order>)
-      #   - Rsyncs the repo to /hosthome/starphleet_dev (which maps to /hosthome)
-      #   - Punts
-      #
-      # After the above process completes we takeover in here and deploy new
-      # containers from the master directory [/hosthome]
-      #
-      # In starphleet_monitor_orders - we listen for changes in the git repo
-      # located in /hosthome and deploy new containers upon changes
+    # Let starphleet be the build system
+    if unique_mode ; then
+      if [ -n "${DEVMODE_UNBIND_GIT_DIR}" ] && [ -f "${LAST_RUN_FILE}" ]; then
+        warn Unbind Mode Detected
 
-      # Use date stamps for containers (that are formatted like shas)
-      #    - Allows normal starphleet commands to operate
-      #    - Gives the user an indication of time of deployment
-      DATE_TIME=$(date +d%y%m%d-d%H%M%S)
-
-      # The 'LAST_RUN_FILE' is created each run for a container.  We use this files
-      # modified time to determine if anything 'new' has been created/changed
-      # since our last deployment of a container
-      LAST_RUN_FILE="/tmp/.${SERVICE_NAME}-starphleet_last_run"
-
-      # TODO: Find out if we have a DEV DIR variable available here somewhere
-      if [ -d "/hosthome/starphleet_dev/${ORDER}" ] && [ -f "${LAST_RUN_FILE}" ]; then
-        # Work around vmware hgfs sync issues on the host OS
-        #   - Basically for now we need to git sync to a local directory
-        #     in the container and then move that directory into the git
-        #     repo of the host ship.. which then gets sync'd upstream
-        #     to the host OS.
-        #
-        #     Here we are seeing if the rsync dir still exists which implies
-        #     it hasn't finished moving to the host OS yet
-        if [ ! -d "/home/admiral/tmp/${ORDER}" ]; then
-          RUNNING=$(lxc-ls -f | grep RUNNING | grep --extended-regexp -e "^${ORDER}-([a-f0-9]){7}-([a-f0-9]){7}"  | cut -f1 -d" ")
-          # **************************************
-          # File Change Detection
-          # **************************************
-          # Define a temp file to check for changed files
-          CHANGED_FILES_FILE="/tmp/${ORDER}.starphleet.newfiles"
-          # Only check for changed files if the they specified to unbind the git dir
-          if [ ! -z ${DEVMODE_UNBIND_GIT_DIR} ]; then
-            # Exclude git and node_modules directory which heavily improves performance.  However,
-            # this requires that some other file be touched and may have unintended consequences.
-            # ...so, this is kinda beta
-            EXCLUDES='-not ( -path *node_modules* -prune ) -and -not ( -path *.git* -prune ) -type f'
-            # Look for a changed file in the directory - punt after the first one
-            find "/hosthome/starphleet_dev/${ORDER}" ${EXCLUDES} -newer "${LAST_RUN_FILE}" -print -quit > "${CHANGED_FILES_FILE}"
-            # Slurp in those files
-            FILES_CHANGED=$(cat ${CHANGED_FILES_FILE})
-            # If there were any changed files
-            if [ ! -z "${FILES_CHANGED}" ]; then
-              # Go through any running containers (albiet, there should only be one)
-              for container in $(echo ${RUNNING}); do
-                # Stop the container
-                warn Redeploying ${container} - ${FILES_CHANGED}
-                # Redeploy the same container.  This will re-run the build script
-                # but sync only the updated files first
-                touch "${LAST_RUN_FILE}"
-                # This should force the container to respawn
-                stop starphleet_serve_order name="${container}"
-                # ...but if it doesn't - we'll start it backup anyway
-                start --no-wait starphleet_serve_order name="${container}" order="${ORDER}"
-              done
-            fi
-            # Cleanup
-            rm ${CHANGED_FILES_FILE}
-          fi
+        # **************************************
+        # File Change Detection
+        # **************************************
+        # Only check for changed files if the they specified to unbind the git dir
+        RUNNING=$(lxc-ls -f | grep RUNNING | grep --extended-regexp -e "^${SERVICE_NAME}-([a-f0-9]){7}-([a-f0-9]){7}"  | cut -f1 -d" ")
+        # Define a temp file to check for changed files
+        CHANGED_FILES_FILE="/tmp/${ORDER}.starphleet.newfiles"
+        # Exclude git and node_modules directory which heavily improves performance.
+        EXCLUDES='-not ( -path *node_modules* -prune ) -and -not ( -path *.git* -prune ) -type f'
+        # Look for a changed file in the directory - punt after the first one
+        find "${LOCAL}" ${EXCLUDES} -newer "${LAST_RUN_FILE}" -print -quit > "${CHANGED_FILES_FILE}"
+        # Slurp in those files
+        FILES_CHANGED=$(cat ${CHANGED_FILES_FILE})
+        # If there were any changed files
+        if [ -n "${FILES_CHANGED}" ]; then
+          # Go through any running containers (albiet, there should only be one)
+          for container in $(echo ${RUNNING}); do
+            # Stop the container
+            warn Redeploying ${container} - ${FILES_CHANGED}
+            # Redeploy the same container.  This will re-run start but not
+            # rebuild all-the-things
+            touch "${LAST_RUN_FILE}"
+            # This should force the container to respawn
+            stop starphleet_serve_order name="${container}"
+            # ...but if it doesn't - we'll start it backup anyway
+            start --no-wait starphleet_serve_order name="${container}" order="${ORDER}"
+          done
+          # Cleanup
+          rm ${CHANGED_FILES_FILE}
           # Cleanup
           unset DEVMODE_UNBIND_GIT_DIR
           unset FILES_CHANGED
@@ -192,6 +144,10 @@ do
       # If no run file exists this container has never been deployed so
       # starphleet must have just started
       if [ ! -f "${LAST_RUN_FILE}" ]  || [ -n "${DEPLOY_REASON}" ]; then
+        # Use date stamps for containers (that are formatted like shas)
+        #    - Allows normal starphleet commands to operate
+        #    - Gives the user an indication of time of deployment
+        DATE_TIME=$(date +d%y%m%d-d%H%M%S)
         # Flag that this has been deployed
         touch "${LAST_RUN_FILE}"
         # Be nice and list why we are deploying
@@ -203,15 +159,12 @@ do
         # Now that we are deploying - make sure we unset our reason
         unset DEPLOY_REASON
       fi
-    else
-      #resynchronize to autodeploy repo, this is the primary case
-      starphleet-git-synch "${SERVICE_GIT_URL}" "${LOCAL}" && DEPLOY_REASON="Updated service"
     fi
   fi
   # If we are in dev mode then there is never a good enough reason in
   # ${DEPLOY_REASON} that we'd want a container with a sha so we
   # force the rest of the code to be skipped
-  if dev_mode ; then
+  if unique_mode ; then
     if [ -n "${UNPUBLISHED}" ] && [ -n "${DEPLOY_REASON}" ]; then
       echo ${ORDERS_SHA} > "${CURRENT_ORDER}/.orders_sha"
       SERVICE_NAME=$(echo "${ORDER}")

--- a/overlay/etc/init/starphleet_monitor_orders.start
+++ b/overlay/etc/init/starphleet_monitor_orders.start
@@ -138,7 +138,7 @@ do
     #versions
     if [ -n "${ORDER}" ] && [ -n "${ORDERS_SHA}" ] && [ -n "${SERVICE_SHA}" ]; then
       dev_mode \
-        && SERVICE_NAME="${ORDER}-$(date +d%y%m%d-d%H%M%S)"
+        && SERVICE_NAME="${ORDER}-$(date +d%y%m%d-d%H%M%S)" \
         || SERVICE_NAME=$(echo "${ORDER}-${ORDERS_SHA}-${SERVICE_SHA}")
     else
       warn "Critical Info Missing - Not Deploying Container:  O: ${ORDER} OS: ${ORDERS_SHA} SS:${SERVICE_SHA}"

--- a/overlay/etc/init/starphleet_monitor_orders.start
+++ b/overlay/etc/init/starphleet_monitor_orders.start
@@ -91,7 +91,7 @@ do
       # Exclude git and node_modules directory which heavily improves performance.
       EXCLUDES='-not ( -path *node_modules* -prune ) -and -not ( -path *.git* -prune ) -type f'
       # Look for a changed file in the directory - punt after the first one
-      find "${LOCAL}" ${EXCLUDES} -newer "${LAST_RUN_FILE}" -print -quit > "${CHANGED_FILES_FILE}"
+      [ -d "${LOCAL}" ] && find "${LOCAL}" ${EXCLUDES} -newer "${LAST_RUN_FILE}" -print -quit > "${CHANGED_FILES_FILE}"
       # Slurp in those files
       FILES_CHANGED=$(cat ${CHANGED_FILES_FILE})
       # If there were any changed files
@@ -127,10 +127,13 @@ do
   if [ -n "${DEPLOY_REASON}" ]; then
     warn "${DEPLOY_REASON}"
     echo ${ORDERS_SHA} > "${CURRENT_ORDER}/.orders_sha"
+    # Unpublished containers may not have a service sha
+    # so set a default just-in-case so these containers
+    # deploy even if they don't have an 'autodeploy'
+    [ -n "${UNPUBLISHED}" ] && SERVICE_SHA="d000000"
     if [ -d "${LOCAL}" ]; then
       get_CURRENT_SHA "${LOCAL}"
       SERVICE_SHA="${CURRENT_SHA}"
-      [ -n "${UNPUBLISHED}" ] && SERVICE_SHA="d000000"
     fi
     #sha for both the service and the orders asking for it, changing either
     #of these starts up a new container that will run in parallel with prior

--- a/overlay/etc/init/starphleet_monitor_orders.start
+++ b/overlay/etc/init/starphleet_monitor_orders.start
@@ -26,18 +26,21 @@ do
   #from the order files in the headquarters
   CURRENT_ORDER="${CURRENT_ORDERS}/${ORDER}"
   mkdir -p "${CURRENT_ORDER}"
+
+  unset ORDERS_DIFF
+  unset DEPLOY_REASON
+
   #use git to determine if the orders have changed since the last publish
   if [ -f "${CURRENT_ORDER}/.orders_sha" ]; then
     DEPLOYED_ORDERS_SHA=$(cat "${CURRENT_ORDER}/.orders_sha")
     get_VERSION_DIFF ${HEADQUARTERS_LOCAL} ${ORDERS_SHA} ${DEPLOYED_ORDERS_SHA} $(dirname "${order}")
-    if [ -n "${VERSION_DIFF}" ]; then
-      ORDERS_DIFF="Updated orders"
-    else
-      ORDERS_DIFF="NONE"
-    fi
+    [ -n "${VERSION_DIFF}" ] && ORDERS_DIFF="Updated orders"
   else
     ORDERS_DIFF="New orders"
   fi
+
+  [ -n "${ORDERS_DIFF}" ] && DEPLOY_REASON="${ORDERS_DIFF}"
+
   # k, so.  in this scope we don't actually care about the betas BUT
   # we do want it to be an associative array... if we DO NOT explicitly
   # make it associative it will implicitly be created as indexed, if you
@@ -52,127 +55,76 @@ do
   #this lets folks get creative in orders files as needed
   unset SERVICE_GIT_URL
   unset UNPUBLISHED
-  unset DEPLOY_REASON
   unset PUBLISH_FROM
+  # Slurp the environment from the orders
   run_orders "${order}"
-  #
+  # If the conditions for the security mode set for this container are not
+  # met then we will not deploy this container.
   if ! validate_security; then
     error "Not Deploying ${order} - Security Not Setup Correctly"
     continue
   fi
-  ###################################
-  # Support for 'publish' command
-  ###################################
-  # The publish command sets a variable called "PUBLISH_FROM" with the the value
-  # being the argument passed to the command.  The value is intended to be
-  # the endpoint we want to publish at a new endpoint.  Below, if PUBLISH_FROM
-  # is set after running the orders AND the endpoint we want to alias does indeed
-  # exist, we will touch a status file resembling ".publish_$location".
-  # The location is basically tells the endpoint to mount itself at 'location' also.
-  #
-  # For example:
-  #   if -f ./current_orders/example1/.publish_example2; then
-  #       /example1 will also publish to /example2
-  #
-  # See: starphleet_nginx_hupper.start for more
-  if [ -n "${PUBLISH_FROM}" ] && [ -d "${CURRENT_ORDERS}${PUBLISH_FROM}" ]; then
-    if [ ! -f "${CURRENT_ORDERS}${PUBLISH_FROM}/.publish_${ORDER}" ]; then
-      warn "Publish Detected: ${CURRENT_ORDERS}${PUBLISH_FROM}/.publish_${ORDER}"
-      touch "${CURRENT_ORDERS}${PUBLISH_FROM}/.publish_${ORDER}"
-      starphleet-hup-nginx
-    fi
-    continue
-  fi
-  [ "${ORDERS_DIFF}" != "NONE" ] && DEPLOY_REASON="${ORDERS_DIFF}"
 
-  #if there is a service repo, pull and synch it
-  if [ -n "${SERVICE_GIT_URL}" ]; then
-    # The directory we store our local git copy
-    LOCAL="${HEADQUARTERS_LOCAL}/${ORDER}/git"
-    # Sync Only Once In Devmode and All The Time If Devmode Disabled
-    (dev_mode && [ -d "${LOCAL}" ]) || (starphleet-git-synch "${SERVICE_GIT_URL}" "${LOCAL}" && DEPLOY_REASON="Updated service")
-    # The name of the service container
-    SERVICE_NAME="${ORDER}"
+
+  # The directory we store our local git copy
+  LOCAL="${HEADQUARTERS_LOCAL}/${ORDER}/git"
+
+
+  if [ -n "${DEVMODE_UNBIND_GIT_DIR}" ] && dev_mode ; then
     # The 'LAST_RUN_FILE' is created each run for a container.  We use this files
     # modified time to determine if anything 'new' has been created/changed
     # since our last deployment of a container
-    LAST_RUN_FILE="/tmp/.${SERVICE_NAME}-starphleet_last_run"
+    LAST_RUN_FILE="/tmp/.${ORDER}-starphleet_last_run"
     ############################################
     # Modified Dev Mode
     ############################################
     # Let starphleet be the build system
-    if dev_mode ; then
-      if [ -n "${DEVMODE_UNBIND_GIT_DIR}" ] && [ -f "${LAST_RUN_FILE}" ]; then
-        warn Unbind Mode Detected
-
-        # **************************************
-        # File Change Detection
-        # **************************************
-        # Only check for changed files if the they specified to unbind the git dir
-        RUNNING=$(lxc-ls -f | grep RUNNING | grep --extended-regexp -e "^${SERVICE_NAME}-([a-f0-9]){7}-([a-f0-9]){7}"  | cut -f1 -d" ")
-        # Define a temp file to check for changed files
-        CHANGED_FILES_FILE="/tmp/${ORDER}.starphleet.newfiles"
-        # Exclude git and node_modules directory which heavily improves performance.
-        EXCLUDES='-not ( -path *node_modules* -prune ) -and -not ( -path *.git* -prune ) -type f'
-        # Look for a changed file in the directory - punt after the first one
-        find "${LOCAL}" ${EXCLUDES} -newer "${LAST_RUN_FILE}" -print -quit > "${CHANGED_FILES_FILE}"
-        # Slurp in those files
-        FILES_CHANGED=$(cat ${CHANGED_FILES_FILE})
-        # If there were any changed files
-        if [ -n "${FILES_CHANGED}" ]; then
-          # Go through any running containers (albiet, there should only be one)
-          for container in $(echo ${RUNNING}); do
-            # Stop the container
-            warn Redeploying ${container} - ${FILES_CHANGED}
-            # Redeploy the same container.  This will re-run start but not
-            # rebuild all-the-things
-            touch "${LAST_RUN_FILE}"
-            # This should force the container to respawn
-            stop starphleet_serve_order name="${container}"
-            # ...but if it doesn't - we'll start it backup anyway
-            start --no-wait starphleet_serve_order name="${container}" order="${ORDER}"
-          done
-          # Cleanup
-          rm ${CHANGED_FILES_FILE}
-          # Cleanup
-          unset DEVMODE_UNBIND_GIT_DIR
-          unset FILES_CHANGED
-          unset CHANGED_FILES_FILE
-          unset RUNNING
-        fi
-      fi
-      # If no run file exists this container has never been deployed so
-      # starphleet must have just started
-      if [ ! -f "${LAST_RUN_FILE}" ]  || [ -n "${DEPLOY_REASON}" ]; then
-        # Use date stamps for containers (that are formatted like shas)
-        #    - Allows normal starphleet commands to operate
-        #    - Gives the user an indication of time of deployment
-        DATE_TIME=$(date +d%y%m%d-d%H%M%S)
-        # Flag that this has been deployed
+    if [ -f "${LAST_RUN_FILE}" ]; then
+      warn Unbind Mode Detected
+      # **************************************
+      # File Change Detection
+      # **************************************
+      # Only check for changed files if the they specified to unbind the git dir
+      RUNNING=$(lxc-ls -f | grep RUNNING | grep --extended-regexp -e "^${ORDER}-([a-f0-9]){7}-([a-f0-9]){7}"  | cut -f1 -d" ")
+      # Define a temp file to check for changed files
+      CHANGED_FILES_FILE="/tmp/${ORDER}.starphleet.newfiles"
+      # Exclude git and node_modules directory which heavily improves performance.
+      EXCLUDES='-not ( -path *node_modules* -prune ) -and -not ( -path *.git* -prune ) -type f'
+      # Look for a changed file in the directory - punt after the first one
+      find "${LOCAL}" ${EXCLUDES} -newer "${LAST_RUN_FILE}" -print -quit > "${CHANGED_FILES_FILE}"
+      # Slurp in those files
+      FILES_CHANGED=$(cat ${CHANGED_FILES_FILE})
+      # If there were any changed files
+      if [ -n "${FILES_CHANGED}" ]; then
+        # Go through any running containers (albiet, there should only be one)
+        for container in $(echo ${RUNNING}); do
+          # Stop the container
+          warn Redeploying ${container} - ${FILES_CHANGED}
+          # This should force the container to respawn
+          stop starphleet_serve_order name="${container}"
+          # ...but if it doesn't - we'll start it backup anyway
+          start --no-wait starphleet_serve_order name="${container}" order="${ORDER}"
+        done
+        # rebuild all-the-things
         touch "${LAST_RUN_FILE}"
-        # Be nice and list why we are deploying
-        warn Dev Mode Deployment: "${DEPLOY_REASON}"
-        # Just like in production - we respect order changes
-        echo ${ORDERS_SHA} > "${CURRENT_ORDER}/.orders_sha"
-        # Deploy with Date Stamps in Dev Mode
-        start --no-wait starphleet_serve_order name="${SERVICE_NAME}-${DATE_TIME}" order="${ORDER}"
-        # Now that we are deploying - make sure we unset our reason
-        unset DEPLOY_REASON
+        # Cleanup
+        rm ${CHANGED_FILES_FILE}
+        # Cleanup
+        unset DEVMODE_UNBIND_GIT_DIR
+        unset FILES_CHANGED
+        unset CHANGED_FILES_FILE
+        unset RUNNING
       fi
     fi
+    # If the file doesn't exist this would be our first deploy.  We need to get the container
+    # started so we'll go ahead and flag the container for start
+    [ ! -f "${LAST_RUN_FILE}" ] && touch "${LAST_RUN_FILE}" && DEPLOY_REASON="First Deploy"
   fi
-  # If we are in dev mode then there is never a good enough reason in
-  # ${DEPLOY_REASON} that we'd want a container with a sha so we
-  # force the rest of the code to be skipped
-  if dev_mode ; then
-    if [ -n "${UNPUBLISHED}" ] && [ -n "${DEPLOY_REASON}" ]; then
-      echo ${ORDERS_SHA} > "${CURRENT_ORDER}/.orders_sha"
-      SERVICE_NAME=$(echo "${ORDER}")
-      DATE_TIME=$(date +d%y%m%d-d%H%M%S)
-      start --no-wait starphleet_serve_order name="${SERVICE_NAME}-${DATE_TIME}" order="${ORDER}"
-    fi
-    continue
-  fi
+
+  # If in dev_mode and the directory already exists we don't sync more than Once
+  # Otherwise, always sync the git dir and deploy on changes
+  dev_mode && [ -d "${LOCAL}" ] || [ -n "${SERVICE_GIT_URL}" ] && starphleet-git-synch "${SERVICE_GIT_URL}" "${LOCAL}" && DEPLOY_REASON="Git Repo Changed"
+
   #if there is any reason to start a container -- well, go to it
   if [ -n "${DEPLOY_REASON}" ]; then
     warn "${DEPLOY_REASON}"
@@ -185,7 +137,9 @@ do
     #of these starts up a new container that will run in parallel with prior
     #versions
     if [ -n "${ORDER}" ] && [ -n "${ORDERS_SHA}" ] && [ -n "${SERVICE_SHA}" ]; then
-      SERVICE_NAME=$(echo "${ORDER}-${ORDERS_SHA}-${SERVICE_SHA}")
+      dev_mode \
+        && SERVICE_NAME="${ORDER}-$(date +d%y%m%d-d%H%M%S)"
+        || SERVICE_NAME=$(echo "${ORDER}-${ORDERS_SHA}-${SERVICE_SHA}")
     else
       warn "Critical Info Missing - Not Deploying Container:  O: ${ORDER} OS: ${ORDERS_SHA} SS:${SERVICE_SHA}"
       continue
@@ -193,4 +147,5 @@ do
     #this is done with no-wait since upstart will prevent duplicate starts
     start --no-wait starphleet_serve_order name="${SERVICE_NAME}" order="${ORDER}"
   fi
+  unset DEPLOY_REASON
 done

--- a/overlay/etc/init/starphleet_monitor_orders.start
+++ b/overlay/etc/init/starphleet_monitor_orders.start
@@ -90,7 +90,7 @@ do
     # The directory we store our local git copy
     LOCAL="${HEADQUARTERS_LOCAL}/${ORDER}/git"
     # Sync Only Once In Devmode and All The Time If Devmode Disabled
-    (unique_mode && [ -d "${LOCAL}" ]) || (starphleet-git-synch "${SERVICE_GIT_URL}" "${LOCAL}" && DEPLOY_REASON="Updated service")
+    (dev_mode && [ -d "${LOCAL}" ]) || (starphleet-git-synch "${SERVICE_GIT_URL}" "${LOCAL}" && DEPLOY_REASON="Updated service")
     # The name of the service container
     SERVICE_NAME="${ORDER}"
     # The 'LAST_RUN_FILE' is created each run for a container.  We use this files
@@ -101,7 +101,7 @@ do
     # Modified Dev Mode
     ############################################
     # Let starphleet be the build system
-    if unique_mode ; then
+    if dev_mode ; then
       if [ -n "${DEVMODE_UNBIND_GIT_DIR}" ] && [ -f "${LAST_RUN_FILE}" ]; then
         warn Unbind Mode Detected
 
@@ -164,7 +164,7 @@ do
   # If we are in dev mode then there is never a good enough reason in
   # ${DEPLOY_REASON} that we'd want a container with a sha so we
   # force the rest of the code to be skipped
-  if unique_mode ; then
+  if dev_mode ; then
     if [ -n "${UNPUBLISHED}" ] && [ -n "${DEPLOY_REASON}" ]; then
       echo ${ORDERS_SHA} > "${CURRENT_ORDER}/.orders_sha"
       SERVICE_NAME=$(echo "${ORDER}")

--- a/overlay/etc/init/starphleet_monitor_orders.start
+++ b/overlay/etc/init/starphleet_monitor_orders.start
@@ -121,9 +121,7 @@ do
     [ ! -f "${LAST_RUN_FILE}" ] && touch "${LAST_RUN_FILE}" && DEPLOY_REASON="First Deploy"
   fi
 
-  # If in dev_mode and the directory already exists we don't sync more than Once
-  # Otherwise, always sync the git dir and deploy on changes
-  dev_mode && [ -d "${LOCAL}" ] || [ -n "${SERVICE_GIT_URL}" ] && starphleet-git-synch "${SERVICE_GIT_URL}" "${LOCAL}" && DEPLOY_REASON="Git Repo Changed"
+  [ -n "${SERVICE_GIT_URL}" ] && starphleet-git-synch "${SERVICE_GIT_URL}" "${LOCAL}" && DEPLOY_REASON="Git Repo Changed"
 
   #if there is any reason to start a container -- well, go to it
   if [ -n "${DEPLOY_REASON}" ]; then

--- a/overlay/etc/init/starphleet_monitor_orders.start
+++ b/overlay/etc/init/starphleet_monitor_orders.start
@@ -118,7 +118,7 @@ do
       #
       # The first container build
       #   - Grabs the git repo to a tmp dir (/home/admiral/tmp/<order>)
-      #   - Rsyncs the repo to /var/git (which maps to /hosthome)
+      #   - Rsyncs the repo to /hosthome/starphleet_dev (which maps to /hosthome)
       #   - Punts
       #
       # After the above process completes we takeover in here and deploy new

--- a/overlay/etc/init/starphleet_monitor_orders.start
+++ b/overlay/etc/init/starphleet_monitor_orders.start
@@ -130,6 +130,7 @@ do
     if [ -d "${LOCAL}" ]; then
       get_CURRENT_SHA "${LOCAL}"
       SERVICE_SHA="${CURRENT_SHA}"
+      [ -n "${UNPUBLISHED}" ] && SERVICE_SHA="d000000"
     fi
     #sha for both the service and the orders asking for it, changing either
     #of these starts up a new container that will run in parallel with prior

--- a/overlay/etc/init/starphleet_monitor_remotes.start
+++ b/overlay/etc/init/starphleet_monitor_remotes.start
@@ -9,8 +9,8 @@ do
     export LOCAL_DIRECTORY=$(echo "${remote}" | sed -e 's[/remote$[[' | sed -e "s[^${HEADQUARTERS_LOCAL}/\?[${STARPHLEET_SHARED_DATA}/[")
     autodeploy () {
       source `which tools`
-      # Only sync one time in unique_mode
-      unique_mode && [ -d "${LOCAL_DIRECTORY}"] || starphleet-git-synch "$1" "${LOCAL_DIRECTORY}"
+      # Only sync one time in dev_mode
+      dev_mode && [ -d "${LOCAL_DIRECTORY}"] || starphleet-git-synch "$1" "${LOCAL_DIRECTORY}"
     }
     export -f autodeploy
     export AUTODEPLOY

--- a/overlay/etc/init/starphleet_monitor_remotes.start
+++ b/overlay/etc/init/starphleet_monitor_remotes.start
@@ -1,6 +1,4 @@
 #!/bin/bash
-
-STARPHLEET_DEV_DIR=/hosthome/starphleet_dev/data
 while [ 1 ]
 do
   source `which tools`
@@ -8,19 +6,11 @@ do
   #auto deploy each ordered remote
   for remote in $(find "${HEADQUARTERS_LOCAL}" | grep '/remote$' | grep -v '/git')
   do
-    if dev_mode ; then
-      export LOCAL_DIRECTORY=$(echo "${remote}" | sed -e 's[/remote$[[' | sed -e "s[^${HEADQUARTERS_LOCAL}/\?[${STARPHLEET_DEV_DIR}/[")
-    else
-      export LOCAL_DIRECTORY=$(echo "${remote}" | sed -e 's[/remote$[[' | sed -e "s[^${HEADQUARTERS_LOCAL}/\?[${STARPHLEET_SHARED_DATA}/[")
-    fi
-
+    export LOCAL_DIRECTORY=$(echo "${remote}" | sed -e 's[/remote$[[' | sed -e "s[^${HEADQUARTERS_LOCAL}/\?[${STARPHLEET_SHARED_DATA}/[")
     autodeploy () {
       source `which tools`
-      # Only checkout a remote once in devmode
-      if dev_mode ; then
-        [ -d "${LOCAL_DIRECTORY}" ] && return
-      fi
-      starphleet-git-synch "$1" "${LOCAL_DIRECTORY}"
+      # Only sync one time in unique_mode
+      unique_mode && [ -d "${LOCAL_DIRECTORY}"] || starphleet-git-synch "$1" "${LOCAL_DIRECTORY}"
     }
     export -f autodeploy
     export AUTODEPLOY

--- a/overlay/etc/init/starphleet_monitor_remotes.start
+++ b/overlay/etc/init/starphleet_monitor_remotes.start
@@ -10,7 +10,7 @@ do
     autodeploy () {
       source `which tools`
       # Only sync one time in dev_mode
-      dev_mode && [ -d "${LOCAL_DIRECTORY}"] || starphleet-git-synch "$1" "${LOCAL_DIRECTORY}"
+      starphleet-git-synch "$1" "${LOCAL_DIRECTORY}"
     }
     export -f autodeploy
     export AUTODEPLOY

--- a/overlay/etc/init/starphleet_serve_order.conf
+++ b/overlay/etc/init/starphleet_serve_order.conf
@@ -9,7 +9,6 @@ instance $name
 # - $order: the directory where the ordered repository is cloned
 
 respawn
-respawn limit 10 600
 
 # upstart doesn't use PAM by design, so limits are managed independently
 # of other (PAM) mechanisms.  Since we're running all sorts of services

--- a/overlay/etc/init/starphleet_serve_order.pre-start
+++ b/overlay/etc/init/starphleet_serve_order.pre-start
@@ -29,6 +29,7 @@ if [ "${name}" == "${LAST_KNOWN_GOOD_CONTAINER}" -a "${name}" == "${DO_WE_HAVE_T
   lxc-attach --name ${name} -- bash starphleet-wait-network
   if dev_mode && [ -n "${DEVMODE_UNBIND_GIT_DIR}" ]; then
     lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "rsync -rlKt '${ORDER_LOCAL}/' '/home/ubuntu/app/'"
+    lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "[ -f '${DEVMODE_BUILD_CACHE}' ] && rsync -rav --exclude-from='${DEVMODE_BUILD_CACHE}' --delete '${ORDER_LOCAL}/' '/home/ubuntu/app/'"
   fi
 else
   warn "creating a new container"

--- a/overlay/etc/init/starphleet_serve_order.pre-start
+++ b/overlay/etc/init/starphleet_serve_order.pre-start
@@ -28,7 +28,7 @@ if [ "${name}" == "${LAST_KNOWN_GOOD_CONTAINER}" -a "${name}" == "${DO_WE_HAVE_T
   starphleet-lxc-wait ${name} RUNNING
   lxc-attach --name ${name} -- bash starphleet-wait-network
   if dev_mode && [ -n "${DEVMODE_UNBIND_GIT_DIR}" ]; then
-    lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "rsync -rlKt '${ORDER_LOCAL}' /home/ubuntu/app/"
+    lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "rsync -rlKt '${ORDER_LOCAL}/' '/home/ubuntu/app/'"
   fi
 else
   warn "creating a new container"

--- a/overlay/etc/init/starphleet_serve_order.pre-start
+++ b/overlay/etc/init/starphleet_serve_order.pre-start
@@ -27,8 +27,8 @@ if [ "${name}" == "${LAST_KNOWN_GOOD_CONTAINER}" -a "${name}" == "${DO_WE_HAVE_T
   lxc-start --name ${name} -d
   starphleet-lxc-wait ${name} RUNNING
   lxc-attach --name ${name} -- bash starphleet-wait-network
-  if dev_mode && [ ! -z ${DEVMODE_UNBIND_GIT_DIR} ]; then
-    lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "rsync -rlKt '/hosthome/starphleet_dev/${order}/' /home/ubuntu/app/"
+  if unique_mode && [ -n "${DEVMODE_UNBIND_GIT_DIR}" ]; then
+    lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "rsync -rlKt '${ORDER_LOCAL}' /home/ubuntu/app/"
   fi
 else
   warn "creating a new container"

--- a/overlay/etc/init/starphleet_serve_order.pre-start
+++ b/overlay/etc/init/starphleet_serve_order.pre-start
@@ -28,7 +28,7 @@ if [ "${name}" == "${LAST_KNOWN_GOOD_CONTAINER}" -a "${name}" == "${DO_WE_HAVE_T
   starphleet-lxc-wait ${name} RUNNING
   lxc-attach --name ${name} -- bash starphleet-wait-network
   if dev_mode && [ ! -z ${DEVMODE_UNBIND_GIT_DIR} ]; then
-    lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "rsync -rlKt '/var/git/${order}/' /home/ubuntu/app/"
+    lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "rsync -rlKt '/hosthome/starphleet_dev/${order}/' /home/ubuntu/app/"
   fi
 else
   warn "creating a new container"

--- a/overlay/etc/init/starphleet_serve_order.pre-start
+++ b/overlay/etc/init/starphleet_serve_order.pre-start
@@ -27,7 +27,7 @@ if [ "${name}" == "${LAST_KNOWN_GOOD_CONTAINER}" -a "${name}" == "${DO_WE_HAVE_T
   lxc-start --name ${name} -d
   starphleet-lxc-wait ${name} RUNNING
   lxc-attach --name ${name} -- bash starphleet-wait-network
-  if unique_mode && [ -n "${DEVMODE_UNBIND_GIT_DIR}" ]; then
+  if dev_mode && [ -n "${DEVMODE_UNBIND_GIT_DIR}" ]; then
     lxc-attach --name ${name} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "rsync -rlKt '${ORDER_LOCAL}' /home/ubuntu/app/"
   fi
 else

--- a/overlay/etc/starphleet
+++ b/overlay/etc/starphleet
@@ -50,6 +50,8 @@ EC2_DRIVES["/dev/xvde"]="/var/lib/lxc/data"
 ##########################################################
 # DEVMODE
 ##########################################################
+export DEVMODE_BUILD_CACHE="${DEVMODE_BUILD_CACHE:-'/home/ubuntu/.devmode_build_cache'}"
+
 unset DEVMODE_UNBIND_GIT_DIR
 unset DEVMODE_FORCE_AUTH
 unset DEVMODE_ENABLED

--- a/overlay/etc/starphleet
+++ b/overlay/etc/starphleet
@@ -48,6 +48,13 @@ EC2_DRIVES["/dev/xvdd"]="/var/log/biglogs"
 EC2_DRIVES["/dev/xvde"]="/var/lib/lxc/data"
 
 ##########################################################
+# DEVMODE
+##########################################################
+unset DEVMODE_UNBIND_GIT_DIR
+unset DEVMODE_FORCE_AUTH
+unset DEVMODE_ENABLED
+
+##########################################################
 # SECURITY
 ##########################################################
 # Security mode can be one of the following:

--- a/scripts/builder
+++ b/scripts/builder
@@ -49,7 +49,7 @@ export REQUEST_ID=$(openssl rand -base64 32)
 
 # the build pack writes to our buildpack dir, and the build pack runs NOT AS ROOT
 sudo chown -R ${STARPHLEET_APP_USER}:${STARPHLEET_APP_USER} ${buildpack_root}
-if unique_mode ; then
+if dev_mode ; then
   rm -rf ${app_root}/.heroku
 fi
 $selected_buildpack/bin/compile "$app_root" "$cache_root"

--- a/scripts/builder
+++ b/scripts/builder
@@ -49,7 +49,7 @@ export REQUEST_ID=$(openssl rand -base64 32)
 
 # the build pack writes to our buildpack dir, and the build pack runs NOT AS ROOT
 sudo chown -R ${STARPHLEET_APP_USER}:${STARPHLEET_APP_USER} ${buildpack_root}
-if dev_mode; then
+if unique_mode ; then
   rm -rf ${app_root}/.heroku
 fi
 $selected_buildpack/bin/compile "$app_root" "$cache_root"

--- a/scripts/starphleet-cleanup
+++ b/scripts/starphleet-cleanup
@@ -10,15 +10,13 @@ test -d ${STARPHLEET_TMP} && rm -rf ${STARPHLEET_TMP}/*
 test -d "${STARPHLEET_TMP}" && rm -rf "${STARPHLEET_TMP}/*"
 test -d "${ADMIRAL_HOME}/.npm" && rm -rf "${ADMIRAL_HOME}/.npm"
 
-#deleting the headquarters makes sure we can get a version difference on start
-#in order to kick off containers
-test -d "${HEADQUARTERS_LOCAL}" && rm -rf "${HEADQUARTERS_LOCAL}"
+# deleting the headquarters makes sure we can get a version difference on start
+# in order to kick off containers
 test -d "${CURRENT_ORDERS}" && rm -rf "${CURRENT_ORDERS}"
 
 # Remove any dev mode run files
 rm /tmp/.*starphleet_last_run 2> /dev/null
 rm /var/log/upstart/starphleet* 2> /dev/null
-rm -rf /home/admiral/tmp 2> /dev/null
 
 #unpublish services from nginx
 test -d "${NGINX_CONF}/published" && rm -rf "${NGINX_CONF}/published"

--- a/scripts/starphleet-containerize
+++ b/scripts/starphleet-containerize
@@ -114,7 +114,7 @@ trace Post-prepping container
 [ -x ${orders_dir}/after_containerize ] && sudo ${orders_dir}/after_containerize
 
 # Keep track of different files from out build process
-sudo rsync -ruvn --delete "${HEADQUARTERS_LOCAL}/${order}/git/" \${APP_IN}/ | grep -iE "^deleting " | sed -e 's|^deleting ||' > ${DEVMODE_BUILD_CACHE}
+devmode && sudo rsync -ruvn --delete "${HEADQUARTERS_LOCAL}/${order}/git/" \${APP_IN}/ | grep -iE "^deleting " | sed -e 's|^deleting ||' > ${DEVMODE_BUILD_CACHE}
 
 trace Container ready
 

--- a/scripts/starphleet-containerize
+++ b/scripts/starphleet-containerize
@@ -60,7 +60,7 @@ if dev_mode; then
   trace Local Dev mode
   if [ "${git_url}" != "-" ]; then
     # Only trample on the current git dir if it doesn't already exist
-    if [ ! -d "/var/git/${order}" ]; then
+    if [ ! -d "/hosthome/starphleet_dev/${order}" ]; then
       # Work around HGFS bug in vmware which pukes on large
       # git checkouts to a sync'd folder between vmware -> host
       #
@@ -80,20 +80,20 @@ if dev_mode; then
       [ -f /home/admiral/tmp/${order} ] && rm -rf /home/admiral/tmp/${order}
       sudo starphleet-git-synch "${git_url}" "/home/admiral/tmp/${order}"
       # Now move the files (once) to the starphleet_dev dir - which, in
-      # the container context where this is running is mapped to /var/git
-      sudo rsync -rlptD "/home/admiral/tmp/${order}/" "/var/git/${order}/" || true
-      sudo chmod -R +w "/var/git/${order}" || true
+      # the container context where this is running is mapped to /hosthome/starphleet_dev
+      sudo rsync -rlptD "/home/admiral/tmp/${order}/" "/hosthome/starphleet_dev/${order}/" || true
+      sudo chmod -R +w "/hosthome/starphleet_dev/${order}" || true
       # Once we remove the temporary directory.. starphleet will try to rebuild
-      # this container because it will detect there was a change in /var/git/<order>
+      # this container because it will detect there was a change in /hosthome/starphleet_dev/<order>
       sudo rm -rf "/home/admiral/tmp/${order}"
     fi
     # Some developers may wish to unbind the GIT directory to the actual app
     # deployment directory so that packages do not mangle their working git
     # directory.  Supporting both behaviors.
     if [ ! -z "${DEVMODE_UNBIND_GIT_DIR}" ]; then
-      sudo rsync -rlKt "/var/git/${order}/" \${APP_IN}/ || true
+      sudo rsync -rlKt "/hosthome/starphleet_dev/${order}/" \${APP_IN}/ || true
     else
-      ln -s /var/git/${order} \${APP_IN} || true
+      ln -s /hosthome/starphleet_dev/${order} \${APP_IN} || true
     fi
     sudo chown -R ubuntu:ubuntu \${APP_IN}
   fi

--- a/scripts/starphleet-containerize
+++ b/scripts/starphleet-containerize
@@ -67,7 +67,7 @@ if [ "${git_url}" != "-" ]; then
     else
       ln -s "${HEADQUARTERS_LOCAL}/${order}/git" \${APP_IN} || true
     fi
-    sudo chown -R ubuntu:ubuntu \${APP_IN}
+    sudo chown -R ubuntu:ubuntu \${APP_IN} || true
   else
     starphleet-git-synch "${git_url}" \${APP_IN}
   fi
@@ -96,9 +96,7 @@ cat << EOF >> ${CONTAINER_BUILD_SCRIPT}
 trace Running buildpack
 if [ -n "\${BUILDPACK_CACHE_DIR}" ]
 then
-  if dev_mode; then
-    trace Buildpack caching is not needed in dev mode
-  else
+  if ! dev_mode ; then
     trace Buildpack caching is enabled
     sudo mkdir -p "\${BUILDPACK_CACHE_DIR}"
     sudo chown -R ${STARPHLEET_APP_USER}:${STARPHLEET_APP_USER} "\${BUILDPACK_CACHE_DIR}"

--- a/scripts/starphleet-containerize
+++ b/scripts/starphleet-containerize
@@ -62,12 +62,15 @@ if [ "${git_url}" != "-" ]; then
     # Some developers may wish to unbind the GIT directory to the actual app
     # deployment directory so that packages do not mangle their working git
     # directory.  Supporting both behaviors.
-    if [ -n "${DEVMODE_UNBIND_GIT_DIR}" ]; then
-      sudo rsync -rlKt "${HEADQUARTERS_LOCAL}/${order}/git/" \${APP_IN}/ || true
-    else
-      ln -s "${HEADQUARTERS_LOCAL}/${order}/git" \${APP_IN} || true
+    if [ -d "${HEADQUARTERS_LOCAL}/${order}/git" ]; then
+      if [ -n "${DEVMODE_UNBIND_GIT_DIR}" ]; then
+        sudo rsync -rlKt "${HEADQUARTERS_LOCAL}/${order}/git/" \${APP_IN}/ || true
+        sudo chown -R ubuntu:ubuntu \${APP_IN} || true
+      else
+        sudo chown -R ubuntu:ubuntu "${HEADQUARTERS_LOCAL}/${order}/git"
+        ln -s "${HEADQUARTERS_LOCAL}/${order}/git" \${APP_IN} || true
+      fi
     fi
-    sudo chown -R ubuntu:ubuntu \${APP_IN} || true
   else
     starphleet-git-synch "${git_url}" \${APP_IN}
   fi

--- a/scripts/starphleet-containerize
+++ b/scripts/starphleet-containerize
@@ -114,7 +114,7 @@ trace Post-prepping container
 [ -x ${orders_dir}/after_containerize ] && sudo ${orders_dir}/after_containerize
 
 # Keep track of different files from out build process
-devmode && sudo rsync -ruvn --delete "${HEADQUARTERS_LOCAL}/${order}/git/" \${APP_IN}/ | grep -iE "^deleting " | sed -e 's|^deleting ||' > ${DEVMODE_BUILD_CACHE}
+dev_mode && sudo rsync -ruvn --delete "${HEADQUARTERS_LOCAL}/${order}/git/" \${APP_IN}/ | grep -iE "^deleting " | sed -e 's|^deleting ||' > ${DEVMODE_BUILD_CACHE}
 
 trace Container ready
 

--- a/scripts/starphleet-containerize
+++ b/scripts/starphleet-containerize
@@ -113,6 +113,9 @@ cronner ${orders_dir} ${ORDERS}
 trace Post-prepping container
 [ -x ${orders_dir}/after_containerize ] && sudo ${orders_dir}/after_containerize
 
+# Keep track of different files from out build process
+sudo rsync -ruvn --delete "${HEADQUARTERS_LOCAL}/${order}/git/" \${APP_IN}/ | grep -iE "^deleting " | sed -e 's|^deleting ||' > ${DEVMODE_BUILD_CACHE}
+
 trace Container ready
 
 EOF

--- a/scripts/starphleet-containerize
+++ b/scripts/starphleet-containerize
@@ -56,49 +56,19 @@ cat << EOF >> ${CONTAINER_BUILD_SCRIPT}
 
 trace Fetching service to \${APP_IN}
 
-if dev_mode; then
-  trace Local Dev mode
-  if [ "${git_url}" != "-" ]; then
-    # Only trample on the current git dir if it doesn't already exist
-    if [ ! -d "/hosthome/starphleet_dev/${order}" ]; then
-      # Work around HGFS bug in vmware which pukes on large
-      # git checkouts to a sync'd folder between vmware -> host
-      #
-      # To work around this pesky issue we allow starphleet to setup
-      # git the first time in a different way.
-      #
-      #    - Check git out to a local dir
-      #    - Rsync that dir to starphleet_dev
-      #    - Punt and let starphleet detect the changes in starphleet_dev
-      #
-      # Here we sync to a temp directory in admiral.  Why?
-      # ... We want starphleet_monitor_orders to not try to rebuild
-      #     this service until the entire repository is synced
-      #     into starphleet_dev.  The way we do this (for now) is
-      #     use a tmp directory that is exposed in both the container
-      #     and the host OS
-      [ -f /home/admiral/tmp/${order} ] && rm -rf /home/admiral/tmp/${order}
-      sudo starphleet-git-synch "${git_url}" "/home/admiral/tmp/${order}"
-      # Now move the files (once) to the starphleet_dev dir - which, in
-      # the container context where this is running is mapped to /hosthome/starphleet_dev
-      sudo rsync -rlptD "/home/admiral/tmp/${order}/" "/hosthome/starphleet_dev/${order}/" || true
-      sudo chmod -R +w "/hosthome/starphleet_dev/${order}" || true
-      # Once we remove the temporary directory.. starphleet will try to rebuild
-      # this container because it will detect there was a change in /hosthome/starphleet_dev/<order>
-      sudo rm -rf "/home/admiral/tmp/${order}"
-    fi
+if [ "${git_url}" != "-" ]; then
+  if dev_mode; then
+    trace Local Dev mode
     # Some developers may wish to unbind the GIT directory to the actual app
     # deployment directory so that packages do not mangle their working git
     # directory.  Supporting both behaviors.
-    if [ ! -z "${DEVMODE_UNBIND_GIT_DIR}" ]; then
-      sudo rsync -rlKt "/hosthome/starphleet_dev/${order}/" \${APP_IN}/ || true
+    if [ -n "${DEVMODE_UNBIND_GIT_DIR}" ]; then
+      sudo rsync -rlKt "${HEADQUARTERS_LOCAL}/${order}/git/" \${APP_IN}/ || true
     else
-      ln -s /hosthome/starphleet_dev/${order} \${APP_IN} || true
+      ln -s "${HEADQUARTERS_LOCAL}/${order}/git" \${APP_IN} || true
     fi
     sudo chown -R ubuntu:ubuntu \${APP_IN}
-  fi
-else
-  if [ "${git_url}" != "-" ]; then
+  else
     starphleet-git-synch "${git_url}" \${APP_IN}
   fi
 fi

--- a/scripts/starphleet-containermake
+++ b/scripts/starphleet-containermake
@@ -38,9 +38,13 @@ fi
 CONTAINER_CONF=${TMPDIR-/tmp}/${CONTAINER_NAME}.conf
 #mounting host system dirs into the lxc container
 
+dev_mode \
+  && STARPHLEET_ROOT_CONTAINER_PERMISSION="rw" \
+  || STARPHLEET_ROOT_CONTAINER_PERMISSION="r"
+
 #starphleet-base is a create, all orders are a clones to delta0
 cat << EOF > ${CONTAINER_CONF}
-lxc.mount.entry = ${STARPHLEET_ROOT} ${CONTAINER_ROOT}/rootfs/${STARPHLEET_ROOT:-var/starphleet} none bind,r 0 0
+lxc.mount.entry = ${STARPHLEET_ROOT} ${CONTAINER_ROOT}/rootfs/${STARPHLEET_ROOT} none bind,${STARPHLEET_ROOT_CONTAINER_PERMISSION} 0 0
 lxc.mount.entry = ${ADMIRAL_HOME} ${CONTAINER_ROOT}/rootfs/${ADMIRAL_HOME} none defaults,bind,create=dir 0 0
 EOF
 

--- a/scripts/starphleet-containermake
+++ b/scripts/starphleet-containermake
@@ -89,18 +89,18 @@ else
     TEST=$(mount | grep /hosthome | grep vmhgfs)
     [ -z "${TEST}" ] && exit 1
     # Proceed with original authors code
-    STARPHLEET_DEV_DIR=/hosthome/starphleet_dev
+    STARPHLEET_DEV_DIR=${STARPHLEET_DEV_DIR:-"/hosthome/starphleet_dev"}
     # Make the dirs
     mkdir -p "${STARPHLEET_DEV_DIR}"
     mkdir -p "${STARPHLEET_DEV_DIR}/data"
-    mkdir -p "${CONTAINER_OVERLAY}/var/git"
+    mkdir -p "${CONTAINER_OVERLAY}/hosthome"
     # Fix the perms on the dirs
     chmod 777 "${STARPHLEET_DEV_DIR}"
-    chmod 777 "${STARPHLEET_DEV_DIR}"
-    chmod 777 "${CONTAINER_OVERLAY}/var/git"
+    chmod 777 "${STARPHLEET_DEV_DIR}/data"
+    chmod 777 "${CONTAINER_OVERLAY}/hosthome"
     # add one additional mount point to the lxc container config.  Wil expose the container git dir to the host
     echo "lxc.mount.entry = ${STARPHLEET_DEV_DIR}/data ${CONTAINER_ROOT}/rootfs/var/data none bind,rw 0 0" >> ${CONTAINER_CONF}
-    echo "lxc.mount.entry = ${STARPHLEET_DEV_DIR} ${CONTAINER_ROOT}/rootfs/var/git none bind,rw 0 0" >> ${CONTAINER_CONF}
+    echo "lxc.mount.entry = ${STARPHLEET_DEV_DIR} ${CONTAINER_ROOT}/rootfs/hosthome none bind,rw 0 0" >> ${CONTAINER_CONF}
   else
     echo "lxc.mount.entry = ${STARPHLEET_SHARED_DATA} ${CONTAINER_ROOT}/rootfs/var/data none rbind,rw 0 0" >> ${CONTAINER_CONF}
   fi

--- a/scripts/starphleet-containermake
+++ b/scripts/starphleet-containermake
@@ -78,33 +78,34 @@ else
     CONTAINER_OVERLAY=${CONTAINER_ROOT}/delta0
   fi
 
-  if dev_mode ; then
-    info Local Dev mode appending mount to ${CONTAINER_CONF}
+  # if dev_mode ; then
+    # info Local Dev mode appending mount to ${CONTAINER_CONF}
     # Edit:  This needs to take into account that these directories are properly
     #        mounted as an HGFS file system or we need to punt completely
     #
     #        This helps survive a reboot where HGFS has not come up yet but
     #        starphleet has started
     # TODO: But what about parallels or virtualbox?
-    if ! mount | grep /hosthome | grep vmhgfs ; then
-      exit 1
-    fi
+    # if ! mount | grep /hosthome | grep vmhgfs ; then
+    #   exit 1
+    # fi
     # Proceed with original authors code
-    HOSTHOME=${HOSTHOME:-"/hosthome"}
-    # Make the dirs
-    mkdir -p "${HOSTHOME}/starphleet_dev"
-    mkdir -p "${HOSTHOME}/starphleet_dev/data"
-    mkdir -p "${CONTAINER_OVERLAY}/hosthome"
-    # Fix the perms on the dirs
-    chmod 777 "${HOSTHOME}/starphleet_dev"
-    chmod 777 "${HOSTHOME}/starphleet_dev/data"
-    chmod 777 "${CONTAINER_OVERLAY}/hosthome"
+    # HOSTHOME=${HOSTHOME:-"/hosthome"}
+    # # Make the dirs
+    # mkdir -p "${HOSTHOME}/starphleet_dev"
+    # mkdir -p "${HOSTHOME}/starphleet_dev/data"
+    # mkdir -p "${CONTAINER_OVERLAY}/hosthome"
+    # # Fix the perms on the dirs
+    # chmod 777 "${HOSTHOME}/starphleet_dev"
+    # chmod 777 "${HOSTHOME}/starphleet_dev/data"
+    # chmod 777 "${CONTAINER_OVERLAY}/hosthome"
     # add one additional mount point to the lxc container config.  Wil expose the container git dir to the host
-    echo "lxc.mount.entry = ${HOSTHOME}/starphleet_dev/data ${CONTAINER_ROOT}/rootfs/var/data none bind,rw 0 0" >> ${CONTAINER_CONF}
-    echo "lxc.mount.entry = ${HOSTHOME} ${CONTAINER_ROOT}/rootfs/hosthome none bind,rw 0 0" >> ${CONTAINER_CONF}
-  else
+    # echo "lxc.mount.entry = ${HOSTHOME}/starphleet_dev/data ${CONTAINER_ROOT}/rootfs/var/data none bind,rw 0 0" >> ${CONTAINER_CONF}
+    # echo "lxc.mount.entry = ${HOSTHOME} ${CONTAINER_ROOT}/rootfs/hosthome none bind,rw 0 0" >> ${CONTAINER_CONF}
+    # echo "lxc.mount.entry = ${STARPHLEET_SHARED_DATA} ${CONTAINER_ROOT}/rootfs/var/data none rbind,rw 0 0" >> ${CONTAINER_CONF}
+  # else
     echo "lxc.mount.entry = ${STARPHLEET_SHARED_DATA} ${CONTAINER_ROOT}/rootfs/var/data none rbind,rw 0 0" >> ${CONTAINER_CONF}
-  fi
+  # fi
 
 
   #make a directory where we can mount back to the ship and a config file to mount

--- a/scripts/starphleet-containermake
+++ b/scripts/starphleet-containermake
@@ -86,21 +86,22 @@ else
     #        This helps survive a reboot where HGFS has not come up yet but
     #        starphleet has started
     # TODO: But what about parallels or virtualbox?
-    TEST=$(mount | grep /hosthome | grep vmhgfs)
-    [ -z "${TEST}" ] && exit 1
+    if ! mount | grep /hosthome | grep vmhgfs ; then
+      exit 1
+    fi
     # Proceed with original authors code
-    STARPHLEET_DEV_DIR=${STARPHLEET_DEV_DIR:-"/hosthome/starphleet_dev"}
+    HOSTHOME=${HOSTHOME:-"/hosthome"}
     # Make the dirs
-    mkdir -p "${STARPHLEET_DEV_DIR}"
-    mkdir -p "${STARPHLEET_DEV_DIR}/data"
+    mkdir -p "${HOSTHOME}/starphleet_dev"
+    mkdir -p "${HOSTHOME}/starphleet_dev/data"
     mkdir -p "${CONTAINER_OVERLAY}/hosthome"
     # Fix the perms on the dirs
-    chmod 777 "${STARPHLEET_DEV_DIR}"
-    chmod 777 "${STARPHLEET_DEV_DIR}/data"
+    chmod 777 "${HOSTHOME}/starphleet_dev"
+    chmod 777 "${HOSTHOME}/starphleet_dev/data"
     chmod 777 "${CONTAINER_OVERLAY}/hosthome"
     # add one additional mount point to the lxc container config.  Wil expose the container git dir to the host
-    echo "lxc.mount.entry = ${STARPHLEET_DEV_DIR}/data ${CONTAINER_ROOT}/rootfs/var/data none bind,rw 0 0" >> ${CONTAINER_CONF}
-    echo "lxc.mount.entry = ${STARPHLEET_DEV_DIR} ${CONTAINER_ROOT}/rootfs/hosthome none bind,rw 0 0" >> ${CONTAINER_CONF}
+    echo "lxc.mount.entry = ${HOSTHOME}/starphleet_dev/data ${CONTAINER_ROOT}/rootfs/var/data none bind,rw 0 0" >> ${CONTAINER_CONF}
+    echo "lxc.mount.entry = ${HOSTHOME} ${CONTAINER_ROOT}/rootfs/hosthome none bind,rw 0 0" >> ${CONTAINER_CONF}
   else
     echo "lxc.mount.entry = ${STARPHLEET_SHARED_DATA} ${CONTAINER_ROOT}/rootfs/var/data none rbind,rw 0 0" >> ${CONTAINER_CONF}
   fi

--- a/scripts/starphleet-containermake
+++ b/scripts/starphleet-containermake
@@ -44,8 +44,8 @@ dev_mode \
 
 #starphleet-base is a create, all orders are a clones to delta0
 cat << EOF > ${CONTAINER_CONF}
-lxc.mount.entry = ${STARPHLEET_ROOT} ${CONTAINER_ROOT}/rootfs/${STARPHLEET_ROOT} none bind,${STARPHLEET_ROOT_CONTAINER_PERMISSION} 0 0
-lxc.mount.entry = ${ADMIRAL_HOME} ${CONTAINER_ROOT}/rootfs/${ADMIRAL_HOME} none defaults,bind,create=dir 0 0
+lxc.mount.entry = ${STARPHLEET_ROOT} ${CONTAINER_ROOT}/rootfs${STARPHLEET_ROOT} none bind,${STARPHLEET_ROOT_CONTAINER_PERMISSION} 0 0
+lxc.mount.entry = ${ADMIRAL_HOME} ${CONTAINER_ROOT}/rootfs${ADMIRAL_HOME} none defaults,bind,create=dir 0 0
 EOF
 
 trap 'rm -rf ${CONTAINER_CONF}' EXIT

--- a/scripts/starphleet-containermake
+++ b/scripts/starphleet-containermake
@@ -78,34 +78,7 @@ else
     CONTAINER_OVERLAY=${CONTAINER_ROOT}/delta0
   fi
 
-  # if dev_mode ; then
-    # info Local Dev mode appending mount to ${CONTAINER_CONF}
-    # Edit:  This needs to take into account that these directories are properly
-    #        mounted as an HGFS file system or we need to punt completely
-    #
-    #        This helps survive a reboot where HGFS has not come up yet but
-    #        starphleet has started
-    # TODO: But what about parallels or virtualbox?
-    # if ! mount | grep /hosthome | grep vmhgfs ; then
-    #   exit 1
-    # fi
-    # Proceed with original authors code
-    # HOSTHOME=${HOSTHOME:-"/hosthome"}
-    # # Make the dirs
-    # mkdir -p "${HOSTHOME}/starphleet_dev"
-    # mkdir -p "${HOSTHOME}/starphleet_dev/data"
-    # mkdir -p "${CONTAINER_OVERLAY}/hosthome"
-    # # Fix the perms on the dirs
-    # chmod 777 "${HOSTHOME}/starphleet_dev"
-    # chmod 777 "${HOSTHOME}/starphleet_dev/data"
-    # chmod 777 "${CONTAINER_OVERLAY}/hosthome"
-    # add one additional mount point to the lxc container config.  Wil expose the container git dir to the host
-    # echo "lxc.mount.entry = ${HOSTHOME}/starphleet_dev/data ${CONTAINER_ROOT}/rootfs/var/data none bind,rw 0 0" >> ${CONTAINER_CONF}
-    # echo "lxc.mount.entry = ${HOSTHOME} ${CONTAINER_ROOT}/rootfs/hosthome none bind,rw 0 0" >> ${CONTAINER_CONF}
-    # echo "lxc.mount.entry = ${STARPHLEET_SHARED_DATA} ${CONTAINER_ROOT}/rootfs/var/data none rbind,rw 0 0" >> ${CONTAINER_CONF}
-  # else
-    echo "lxc.mount.entry = ${STARPHLEET_SHARED_DATA} ${CONTAINER_ROOT}/rootfs/var/data none rbind,rw 0 0" >> ${CONTAINER_CONF}
-  # fi
+  echo "lxc.mount.entry = ${STARPHLEET_SHARED_DATA} ${CONTAINER_ROOT}/rootfs/var/data none rbind,rw 0 0" >> ${CONTAINER_CONF}
 
 
   #make a directory where we can mount back to the ship and a config file to mount

--- a/scripts/starphleet-devmode-update-local-ip
+++ b/scripts/starphleet-devmode-update-local-ip
@@ -15,12 +15,10 @@
 # Don't run if not on a Mac
 [ "$(uname -s)" != "Darwin" ] && exit 0
 
-mkdir -p "${HOME}/starphleet_dev/data"
-
 ifconfig -a \
   | grep -A2 en \
   | grep -v inet6 \
   | grep inet \
   | grep -v 127.0 \
   | awk '{print $2}' \
-  | head -n 1 > "${HOME}/starphleet_dev/data/.localhostip"
+  | head -n 1 > "${HOME}/starphleet_data/.localhostip"

--- a/scripts/starphleet-git-synch
+++ b/scripts/starphleet-git-synch
@@ -23,6 +23,8 @@ reclone () {
   starphleet-git clone -b ${BRANCH} "${REMOTE}" "${local}" || fatal clone error
 }
 
+dev_mode && [ -d "${local}/.git" ] && exit 1
+
 if [ -d "${local}/.git" ]; then
   info synch ${remote} to ${local}
   cd "${local}"

--- a/scripts/starphleet-headquarters
+++ b/scripts/starphleet-headquarters
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#! /usr/bin/env starphleet-launcher
 ### Usage:
 ###    starphleet-headquarters [<url>]
 ### --help
@@ -9,11 +9,8 @@
 ### branch rather than default master.
 ###
 ### If <url> is not specified, this script will try to print the headquarters.
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source "${DIR}/tools"
-help=$(grep "^### " "$0" | cut -c 5-)
-eval "$(${DIR}/docopts -h "$help" -V "$version" : "$@")"
-set -e
+
+run_as_root_or_die
 
 if [ -n "${url}" ]; then
   echo export HEADQUARTERS_REMOTE="${url}" > "${HEADQUARTERS_SOURCE}"

--- a/scripts/starphleet-headquarters
+++ b/scripts/starphleet-headquarters
@@ -14,6 +14,7 @@ run_as_root_or_die
 
 if [ -n "${url}" ]; then
   echo export HEADQUARTERS_REMOTE="${url}" > "${HEADQUARTERS_SOURCE}"
+  [ -d "${HEADQUARTERS_LOCAL}" ] && rm -rf "${HEADQUARTERS_LOCAL}"/..?* "${HEADQUARTERS_LOCAL}"/.[!.]* ${HEADQUARTERS_LOCAL}/*
   info Headquarters set to ${url}
 elif [ -f "${HEADQUARTERS_SOURCE}" ]; then
   info Headquarters is $(cat ${HEADQUARTERS_SOURCE})

--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -149,13 +149,6 @@ test -d ${PRIVATE_KEYS} || mkdir -p ${PRIVATE_KEYS}
 chmod 755 ${PRIVATE_KEYS}
 test -d ${PUBLIC_KEYS} || mkdir -p ${PUBLIC_KEYS}
 chmod 755 ${PUBLIC_KEYS}
-#force install private and public keys from local vagrant image
-if find /starphleet/private_keys/* > /dev/null ; then
-  [ -d "${PRIVATE_KEYS}" ] && cp /starphleet/private_keys/* "${PRIVATE_KEYS}"
-fi
-if find /starphleet/public_keys/* > /dev/null ; then
-  [ -d "${PUBLIC_KEYS}" ] && cp /starphleet/public_keys/* "${PUBLIC_KEYS}"
-fi
 
 #allow passwordless sudoers
 cat > ${ROOT}/etc/sudoers <<'EOF'

--- a/scripts/starphleet-reaper
+++ b/scripts/starphleet-reaper
@@ -18,19 +18,6 @@ do
   # Determine where nginx is pointing
   NGINX_CONTAINER=$(curl --connect-timeout 1 -s -XHEAD -i "http://localhost/${order}/" | grep "X-Starphleet-Container" | cut -f 2 -d " " | tr -dc '[[:print:]]')
 
-  # XXX: After this feature has been live a bit we can purge this...
-  #      For now, I'd like to quickly be able to resort to this Even
-  #      in production for quick debugging
-  if dev_mode ; then
-    log "NM: |${name}|"
-    log "OR: |${order}|"
-    log "SN: |${current_service_name}|"
-    log "CS: |${CURRENT_STATUS}|"
-    log "SF: |${STATUS_FILE}|"
-    log "CC: |${CURRENT_CONTAINER}|"
-    log "NC: |${NGINX_CONTAINER}|"
-  fi
-
   # *****************************
   # Guards
   # *****************************

--- a/scripts/starphleet-redeploy
+++ b/scripts/starphleet-redeploy
@@ -8,7 +8,7 @@
 run_as_root_or_die
 
 starphleet-reaper zzzzzzzzz "${order}" --force
-rm -rf ${HEADQUARTERS_LOCAL}/${order}/git
+! dev_mode && rm -rf ${HEADQUARTERS_LOCAL}/${order}/git
 rm -rf ${CURRENT_ORDERS}/${order}/git
 # Force a redeploy of unpublished orders which don't include GIT repos
 rm "${CURRENT_ORDERS}/${order}/.orders_sha"

--- a/scripts/starphleet-status
+++ b/scripts/starphleet-status
@@ -121,12 +121,7 @@ EOF
     info "  --"
     info "    "
 
-    # The git directories are relocated in dev_mode
-    if dev_mode; then
-      ORDER_LOCAL="${STARPHLEET_DEV_DIR}/${ORDER}"
-    else
-      ORDER_LOCAL="${HEADQUARTERS_LOCAL}/${ORDER}/git"
-    fi
+    ORDER_LOCAL="${HEADQUARTERS_LOCAL}/${ORDER}/git"
 
     # Snag GIT infoz
     if [ -d "${ORDER_LOCAL}" ]; then

--- a/scripts/tools
+++ b/scripts/tools
@@ -283,8 +283,6 @@ function dev_mode() {
     false
   elif [ -d /hosthome ]; then
     true
-  elif [ -d /var/git ]; then
-    true
   else
     false
   fi

--- a/scripts/tools
+++ b/scripts/tools
@@ -278,6 +278,16 @@ function container_environment() {
   export PATH=${PATH}:/usr/local/bin
 }
 
+function unique_mode() {
+  if [ -f /var/starphleet/live ]; then
+    false
+  elif [ -d /hosthome ]; then
+    true
+  else
+    false
+  fi
+}
+
 function dev_mode() {
   if [ -f /var/starphleet/live ]; then
     false

--- a/scripts/tools
+++ b/scripts/tools
@@ -278,20 +278,8 @@ function container_environment() {
   export PATH=${PATH}:/usr/local/bin
 }
 
-function unique_mode() {
-  if [ -f /var/starphleet/live ]; then
-    false
-  elif [ -d /hosthome ]; then
-    true
-  else
-    false
-  fi
-}
-
 function dev_mode() {
-  if [ -f /var/starphleet/live ]; then
-    false
-  elif [ -d /hosthome ]; then
+  if [ -n "${DEVMODE_ENABLED}" ]
     true
   else
     false

--- a/scripts/tools
+++ b/scripts/tools
@@ -279,7 +279,7 @@ function container_environment() {
 }
 
 function dev_mode() {
-  if [ -n "${DEVMODE_ENABLED}" ]
+  if [ -n "${DEVMODE_ENABLED}" ]; then
     true
   else
     false

--- a/virtualbox
+++ b/virtualbox
@@ -1,20 +1,184 @@
 #!/usr/bin/env bash
-if vagrant plugin list | grep -s vagrant-triggers; then
-  echo "vagrant-triggers already installed"
-else
-  echo "installing prerequisite vagrant-triggers"
-  vagrant plugin install vagrant-triggers
+#######################################################################
+## Author:          Benjamin Hudgens
+## Date:            March 28, 2015
+##
+## Description:     Setup the necessary environment to install
+##                  starphleet via vagrant
+#######################################################################
+
+# *********************
+# Config
+# *********************
+
+ENVIRONMENT_FILE="${HOME}/.starphleet"
+STARPHLEET_DEV_DIR="${HOME}/starphleet_dev"
+STARPHLEET_PRIVATE_KEY_FILE="${HOME}/.ssh/starphleet"
+
+# *********************
+# Fix Promiscuious mode crash
+#
+# Bug Fix
+#   See:  https://github.com/coreos/coreos-vagrant/issues/123
+# *********************
+
+sudo touch '/Library/Preferences/VMware Fusion/promiscAuthorized'
+
+# *********************
+# Helpers
+# *********************
+
+function test_git() {
+  SUCCESS=$(ssh -i ${1} git@github.com 2>&1 | grep "successfully authenticated")
+}
+
+function get_starphleet_branch() {
+  read -p "Which branch for your Headquarters: " STARPHLEET_HEADQUARTERS_BRANCH
+}
+
+function headquarters_branch_help() {
+cat <<EOF
+
+  In development mode it is strongly recommended that you create a branch for
+  yourself in the development headquarters git repo.
+
+  The concensus is that it is rude to make changes to the main branch unless
+  they are global and are intended for everyone to consume.
+
+  Current Headquarters:  ${STARPHLEET_HEADQUARTERS}
+
+EOF
+}
+
+function starphleet_dev_help() {
+cat <<EOF
+
+  The starphleet dev directory already exists on your machine.  This implies
+  you may have previous work still in this directory:
+
+    ${STARPHLEET_DEV_DIR}
+
+  If you are doing a clean install of a new headquarters you may want to remove
+  this directory and start fresh.
+
+EOF
+}
+
+function stale_vagrant_help() {
+cat <<EOF
+
+
+  ---------------------
+  !!WARNING!!
+
+  It is possible you did not cleanly destroy a previous vagrant installation.
+  This may have left stale data in your local machines "/etc/hosts" file.
+  You may be unable to reach your ship after a successful deployment.
+
+  You most likely want to remove this stale data before installing.  You can
+  cleanup this data by editing the following file:
+
+      /etc/hosts
+
+  You should remove any lines that are similar to this:
+
+      ## vagrant-hostmanager-start id: f2ae1ca9-1ddf-419e-a3e8-37fd4f23143a
+      172.16.114.129	ship ship ship.local ship.glgresearch.com
+      ## vagrant-hostmanager-end
+
+EOF
+}
+
+function key_help() {
+cat <<EOF
+
+  You must put a non-password protected key file here:
+
+     ${STARPHLEET_PRIVATE_KEY_FILE}
+
+
+  To generate a new key you can try (do not enter a password - hit <enter>):
+
+    ssh-keygen -b 1024 -t rsa -f ${HOME}/.ssh/starphleet
+
+
+  Make sure your key is setup with GitHub.  Read here:
+
+    https://help.github.com/articles/generating-ssh-keys/
+
+EOF
+}
+
+# *********************
+# Environment Setup
+# *********************
+
+# Check if the user has an environment file
+[ -f "${ENVIRONMENT_FILE}" ] && source "${ENVIRONMENT_FILE}"
+
+# If the user doesn't cleanly shutdown vagrant it can leave
+# stale host records in /etc/hosts
+# Let's warn them and possibly punt
+if [ "$(cat /etc/hosts | grep 'vagrant-hostmanager')" != "" ]; then
+  stale_vagrant_help
+  unset ANSWER
+  read -p "Do you want to exit and fix this? [y/N]: " ANSWER
+
+  if [ "${ANSWER}" == "y" ] || [ "${ANSWER}" == "Y" ]; then
+    exit 1
+  fi
 fi
 
-if vagrant plugin list | grep -s vagrant-hostmanager; then
-  echo "vagrant-hostmanager already installed"
-else
-  echo "installing prerequisite vagrant-hostmanager"
-  vagrant plugin install vagrant-hostmanager
+# Make sure a headquarters is set
+if [ -z "${STARPHLEET_HEADQUARTERS}" ]; then
+  read -p "Please paste a starphleet headquarters: " STARPHLEET_HEADQUARTERS
+  export STARPHLEET_HEADQUARTERS="${STARPHLEET_HEADQUARTERS}"
 fi
 
-if [ -f ~/.starphleet ] ; then
-  source ~/.starphleet && vagrant up --provider virtualbox
-else
-  echo "~/.starphleet not found"
+# Require users to specify a branch explicitly so they remember not to trample
+# on everyone else.  If their headquarters doesn't contain a branch .. prompt
+if [ -z "$(echo ${STARPHLEET_HEADQUARTERS} | grep '#')" ]; then
+  headquarters_branch_help
+  get_starphleet_branch
+  # They should now have a branch set - so if the variable isn't empty
+  # that's good and we set the branch on their headquarters.  Otherwise,
+  # at this point we should not proceed
+  if [ -n "${STARPHLEET_HEADQUARTERS_BRANCH}" ]; then
+    export STARPHLEET_HEADQUARTERS="${STARPHLEET_HEADQUARTERS}#${STARPHLEET_HEADQUARTERS_BRANCH}"
+  else
+    exit 1
+  fi
 fi
+
+
+# Graceful fallback if the user didn't setup the keys in their environment
+if [ -z "${STARPHLEET_PRIVATE_KEY}" ]; then
+  # Test to make sure their key connects to github without issue
+  [ -f "${STARPHLEET_PRIVATE_KEY_FILE}" ] && \
+  test_git "${STARPHLEET_PRIVATE_KEY_FILE}"
+  # If success - export the starphleet key
+  if [ ! -z "${SUCCESS}" ]; then
+    export STARPHLEET_PRIVATE_KEY="${STARPHLEET_PRIVATE_KEY_FILE}"
+  else
+    # Starphleet key didn't work out - be a pal and try their default key
+    test_git "${HOME}/.ssh/id_rsa"
+    if [ ! -z "${SUCCESS}" ]; then
+      export STARPHLEET_PRIVATE_KEY="${HOME}/.ssh/id_rsa"
+    else
+      # Sheesh - nothing is working
+      key_help
+      exit 1
+    fi
+  fi
+fi
+
+# *********************
+# Main
+# *********************
+
+echo Starphleet HQ:     ${STARPHLEET_HEADQUARTERS}
+echo SSH Private Key:   ${STARPHLEET_PRIVATE_KEY}
+
+echo "Go get some coffee.  This will take a while..."
+
+vagrant up --provider vmware_fusion

--- a/virtualbox
+++ b/virtualbox
@@ -181,4 +181,4 @@ echo SSH Private Key:   ${STARPHLEET_PRIVATE_KEY}
 
 echo "Go get some coffee.  This will take a while..."
 
-vagrant up --provider vmware_fusion
+vagrant up --provider virtualbox

--- a/vmware
+++ b/vmware
@@ -14,7 +14,6 @@
 ENVIRONMENT_FILE="${HOME}/.starphleet"
 STARPHLEET_DEV_DIR="${HOME}/starphleet_dev"
 STARPHLEET_PRIVATE_KEY_FILE="${HOME}/.ssh/starphleet"
-STARPHLEET_PUBLIC_KEY_FILE="${HOME}/.ssh/starphleet.pub"
 
 # *********************
 # Fix Promiscuious mode crash
@@ -96,7 +95,6 @@ cat <<EOF
   You must put a non-password protected key file here:
 
      ${STARPHLEET_PRIVATE_KEY_FILE}
-     ${STARPHLEET_PUBLIC_KEY_FILE}
 
 
   To generate a new key you can try (do not enter a password - hit <enter>):
@@ -144,7 +142,7 @@ if [ -d "${STARPHLEET_DEV_DIR}" ]; then
 fi
 
 # Make sure a headquarters is set
-if [ -z ${STARPHLEET_HEADQUARTERS} ]; then
+if [ -z "${STARPHLEET_HEADQUARTERS}" ]; then
   read -p "Please paste a starphleet headquarters: " STARPHLEET_HEADQUARTERS
   export STARPHLEET_HEADQUARTERS="${STARPHLEET_HEADQUARTERS}"
 fi
@@ -157,7 +155,7 @@ if [ -z "$(echo ${STARPHLEET_HEADQUARTERS} | grep '#')" ]; then
   # They should now have a branch set - so if the variable isn't empty
   # that's good and we set the branch on their headquarters.  Otherwise,
   # at this point we should not proceed
-  if [ ! -z "${STARPHLEET_HEADQUARTERS_BRANCH}" ]; then
+  if [ -n "${STARPHLEET_HEADQUARTERS_BRANCH}" ]; then
     export STARPHLEET_HEADQUARTERS="${STARPHLEET_HEADQUARTERS}#${STARPHLEET_HEADQUARTERS_BRANCH}"
   else
     exit 1
@@ -166,21 +164,18 @@ fi
 
 
 # Graceful fallback if the user didn't setup the keys in their environment
-if [ -z "${STARPHLEET_PRIVATE_KEY}" ] || [ -z "${STARPHLEET_PUBLIC_KEY}" ]; then
+if [ -z "${STARPHLEET_PRIVATE_KEY}" ]; then
   # Test to make sure their key connects to github without issue
   [ -f "${STARPHLEET_PRIVATE_KEY_FILE}" ] && \
-  [ -f "${STARPHLEET_PUBLIC_KEY_FILE}" ] && \
   test_git "${STARPHLEET_PRIVATE_KEY_FILE}"
   # If success - export the starphleet key
   if [ ! -z "${SUCCESS}" ]; then
     export STARPHLEET_PRIVATE_KEY="${STARPHLEET_PRIVATE_KEY_FILE}"
-    export STARPHLEET_PUBLIC_KEY="${STARPHLEET_PUBLIC_KEY_FILE}"
   else
     # Starphleet key didn't work out - be a pal and try their default key
     test_git "${HOME}/.ssh/id_rsa"
     if [ ! -z "${SUCCESS}" ]; then
       export STARPHLEET_PRIVATE_KEY="${HOME}/.ssh/id_rsa"
-      export STARPHLEET_PUBLIC_KEY="${HOME}/.ssh/id_rsa.pub"
     else
       # Sheesh - nothing is working
       key_help
@@ -194,7 +189,6 @@ fi
 # *********************
 
 echo Starphleet HQ:     ${STARPHLEET_HEADQUARTERS}
-echo SSH Public Key:    ${STARPHLEET_PUBLIC_KEY}
 echo SSH Private Key:   ${STARPHLEET_PRIVATE_KEY}
 
 echo "Go get some coffee.  This will take a while..."

--- a/vmware
+++ b/vmware
@@ -129,18 +129,6 @@ if [ "$(cat /etc/hosts | grep 'vagrant-hostmanager')" != "" ]; then
   fi
 fi
 
-# If the dev dir exists - maybe they have some previous work in that directory..
-# we should ask if they want to delete it first
-if [ -d "${STARPHLEET_DEV_DIR}" ]; then
-  starphleet_dev_help
-  unset ANSWER
-  read -p "Do you want to delete the ~/starphleet_dev directory? [y/N]: " ANSWER
-  # Remove the dev dor upon request
-  if [ "${ANSWER}" == "y" ] || [ "${ANSWER}" == "Y" ]; then
-    rm -rf "${STARPHLEET_DEV_DIR}"
-  fi
-fi
-
 # Make sure a headquarters is set
 if [ -z "${STARPHLEET_HEADQUARTERS}" ]; then
   read -p "Please paste a starphleet headquarters: " STARPHLEET_HEADQUARTERS

--- a/vmware
+++ b/vmware
@@ -200,10 +200,3 @@ echo SSH Private Key:   ${STARPHLEET_PRIVATE_KEY}
 echo "Go get some coffee.  This will take a while..."
 
 vagrant up --provider vmware_fusion
-
-# Give starphleet a few seconds to warm up before we go test things
-echo "One moment while devmode initalizes.  This may take a while..."
-sleep 10
-
-# Now test how things are going
-vagrant ssh -c "sudo starphleet-devmode-install-check"

--- a/webinstall
+++ b/webinstall
@@ -19,12 +19,12 @@ STARPHLEET_BRANCH=${STARPHLEET_BRANCH:-master}
 ## Main Foo
 ##############################################################################
 
-read -p "Please paste the SSH git URL to your headquarters:  " HEADQUARTERS_URL
+[ -n "${HEADQUARTERS_URL}" ] || read -p "Please paste the SSH git URL to your headquarters:  " HEADQUARTERS_URL
 
 # We're gonna need git
 apt-get install -y git
 # Now grab this repo
-git clone -b ${STARPHLEET_BRANCH} ${STARPHLEET_REPO}
+git clone -b "${STARPHLEET_BRANCH}" "${STARPHLEET_REPO}"
 # Head into scripts
 cd starphleet/scripts
 # Move launcher into place
@@ -32,7 +32,7 @@ cp ./starphleet-launcher /usr/bin
 # Let the magic begin
 ./starphleet-install
 # Set the headquarters
-starphleet-headquarters ${HEADQUARTERS_URL}
+starphleet-headquarters "${HEADQUARTERS_URL}"
 
 source `which tools`
 


### PR DESCRIPTION
* Devmode is now an environment configuration
* Devmode primarily now prevents git-synchs from overriding existing files
* Core files no longer go over HGFS (huge performance gains / Using NFS instead)
  * Allows HQ modification on Host OS  
  * No longer has buggy interactions with HGFS.  
* Install now syncs to "Starphleet Host" instead of going over HGFS
* Make HOST OS ip exposed during vagrant up automatically
* Make starphleet_serve_order never give up
* Remove concept of Pub Key (Vagrant does not need)
* Fixes link to VIrtualBox Image
* Fix hostmanager config in Vagrantfile
* Fixes networking on VirtualBox 
* Remove concept of 'publish'
* VirtualBox now supported (./virtualbox init scripts helper)
* slim up dev_mode code in starphleet_monitor_orders
* Make starphleet-headquarters use starphleet-launcher
* Remove funky binds in starphleet-containermake
* Starphleet Host machine file structure is now same as production
* Mount (via NFS) /var/starphleet/headquarters -> ${HOME}/starphleet_dev
* Mount (via NFS) /var/lib/lxc/data -> ${HOME}/starphleet_data
* starphleet-headquarters now purges HQ dir
* webinstall script now supports HEADQUARTERS_URL default