### PR TITLE
NOT YET: strip out malformed beta groups

### DIFF
--- a/scripts/starphleet-beta-groups
+++ b/scripts/starphleet-beta-groups
@@ -37,7 +37,7 @@ do
   #cookie style
   echo "  map \$cookie_${USER_IDENTITY_COOKIE} \$starphleet_beta_$(basename ${BETA_GROUP})_cookie  {" >> "${BETA_GROUP_CONF}"
   echo "   default 0;" >> "${BETA_GROUP_CONF}"
-  for BETA_USER in $(cat "${BETA_GROUP}" | tr '[:upper:]' '[:lower:]' | sort | uniq)
+  for BETA_USER in $(cat "${BETA_GROUP}" | grep -v -E '^#|^$|[[:space:]]' | tr '[:upper:]' '[:lower:]' | sort | uniq)
   do
     echo "   ${BETA_USER} 1;" >> "${BETA_GROUP_CONF}"
   done


### PR DESCRIPTION
This pull request removes any line from a beta group file which:

1. Is empty
2. Contains any whitespace
3. Begins with the `bash` comment character, `#`

Making this change will prevent errors within starphleet when a malformed beta group user is passed to other parts of Starphleet.  **This code has not fully completed testing**.