### PR TITLE
Pass the secret from the parent container

### DIFF
--- a/overlay/var/starphleet/nginx/lua/jwt.lua
+++ b/overlay/var/starphleet/nginx/lua/jwt.lua
@@ -49,6 +49,7 @@ end
 local _sendUserToLogin = function()
   local redirectUrl = ngx.var.request_uri
   redirectUrl = _replace(redirectUrl, ngx.var.public_url, jwt_auth_site)
+  ngx.req.set_header('X-Starphleet-JWT-Secret', jwt_secret);
   ngx.req.set_header('X-Starphleet-Redirect', "true");
   ngx.req.set_header('X-Starphleet-OriginalUrl', ngx.var.request_uri);
   ngx.req.set_header('X-Starphleet-Authentic', ngx.var.authentic_token);


### PR DESCRIPTION
- Pass the JWT Secret from the redirected container so JWT does not have
  to depend on multiple login apps