### PR TITLE
Bug:  htpasswd is not cached

### DIFF
--- a/overlay/etc/init/starphleet_nginx_hupper.start
+++ b/overlay/etc/init/starphleet_nginx_hupper.start
@@ -21,7 +21,6 @@ do
     rm "${NGINX_CONF}"/published_bare/* 2> /dev/null
     rm "${NGINX_CONF}"/proxy_for/* 2> /dev/null
     rm "${NGINX_CONF}"/named_servers/* 2> /dev/null
-    rm "${NGINX_CONF}"/htpasswd/* 2> /dev/null
 
     # Run all the accessory nginx configuration tools
     starphleet-ldap-servers


### PR DESCRIPTION
- The file being purged actually affects the live server.  Thus, we'll
  just have to allow clutter in this folder but not purge