### PR TITLE
Bump Max Body Size

### DIFF
--- a/overlay/var/starphleet/nginx/proxy.conf
+++ b/overlay/var/starphleet/nginx/proxy.conf
@@ -2,7 +2,7 @@ proxy_redirect          off;
 proxy_set_header        Host            $host;
 proxy_set_header        X-Real-IP       $remote_addr;
 proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-client_max_body_size    10m;
+client_max_body_size    25m;
 client_body_buffer_size 128k;
 proxy_connect_timeout   90;
 proxy_send_timeout      90;


### PR DESCRIPTION
- Prevents simple file uploads > 10m.  Bumping to support larger sizes.