### PR TITLE
Allow "auto" auth to optionally be disabled

### DIFF
--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -146,14 +146,16 @@ if [ "${SECURITY_MODE}" = 'ldap' ]; then
   echo "  proxy_set_header ${USER_IDENTITY_HEADER} \$remote_user;" >> "${MOUNT_CONF}"
   echo "  add_header Set-Cookie ${USER_IDENTITY_COOKIE}=\$remote_user;" >> "${MOUNT_CONF}"
 fi
-if [ "${SECURITY_MODE}" != 'public' ] || [ -n "${DISABLE_AUTO_AUTH}" ] && ! dev_mode ; then
-  # don't want to ldap authenticate from other containers on the ship
-  # see http://forum.nginx.org/read.php?2,242713,242742#msg-242742
-  # note: this needs an auth_basic that alway fails and has the same name as auth_ldap
-  echo "  satisfy any;" >> "${MOUNT_CONF}"
-  echo "  allow 192.168.0.0/16;" >> "${MOUNT_CONF}"
-  echo "  allow 172.16.0.0/12;" >> "${MOUNT_CONF}"
-  echo "  allow 10.0.0.0/8;" >> "${MOUNT_CONF}"
+if [ -z "${DISABLE_AUTO_AUTH}" ]; then
+  if [ "${SECURITY_MODE}" != 'public' ] && ! dev_mode ; then
+    # don't want to ldap authenticate from other containers on the ship
+    # see http://forum.nginx.org/read.php?2,242713,242742#msg-242742
+    # note: this needs an auth_basic that alway fails and has the same name as auth_ldap
+    echo "  satisfy any;" >> "${MOUNT_CONF}"
+    echo "  allow 192.168.0.0/16;" >> "${MOUNT_CONF}"
+    echo "  allow 172.16.0.0/12;" >> "${MOUNT_CONF}"
+    echo "  allow 10.0.0.0/8;" >> "${MOUNT_CONF}"
+  fi
 fi
 
 #closing off the location

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -146,7 +146,7 @@ if [ "${SECURITY_MODE}" = 'ldap' ]; then
   echo "  proxy_set_header ${USER_IDENTITY_HEADER} \$remote_user;" >> "${MOUNT_CONF}"
   echo "  add_header Set-Cookie ${USER_IDENTITY_COOKIE}=\$remote_user;" >> "${MOUNT_CONF}"
 fi
-if [ "${SECURITY_MODE}" != 'public' ] && ! dev_mode ; then
+if [ "${SECURITY_MODE}" != 'public' ] || [ -n "${DISABLE_AUTO_AUTH}" ] && ! dev_mode ; then
   # don't want to ldap authenticate from other containers on the ship
   # see http://forum.nginx.org/read.php?2,242713,242742#msg-242742
   # note: this needs an auth_basic that alway fails and has the same name as auth_ldap


### PR DESCRIPTION
- There are instances where Starphleet might be running on a private
  network intentionally and you might not want auto auth enabled