### PR TITLE
Bug: Fix local healthchecks

### DIFF
--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -171,6 +171,7 @@ if [ -z "${DISABLE_AUTO_AUTH}" ]; then
     echo "  allow 192.168.0.0/16;" >> "${MOUNT_CONF}"
     echo "  allow 172.16.0.0/12;" >> "${MOUNT_CONF}"
     echo "  allow 10.0.0.0/8;" >> "${MOUNT_CONF}"
+    echo "  allow 127.0.0.0/8;" >> "${MOUNT_CONF}"
   fi
 fi
 


### PR DESCRIPTION
This fixes the issue where JWT containers reap the active container before the new container is available.  The reaper will now correctly see that the active container is being pointed out and not reap until it's appropriate.