### PR TITLE
WIP - NOT READY - Storing Containers On S3

### DIFF
--- a/overlay/etc/init/starphleet_serve_order.post-start
+++ b/overlay/etc/init/starphleet_serve_order.post-start
@@ -57,17 +57,30 @@ else
     done
   fi
 
+  # At this point we know we have a 'good' container and we'll
+  # want to store it on S3 if configured for that.  It's possible the same
+  # machine that is building a container is also serving it
+  # so we will `|| true` here to not allow the S3 upload process
+  # to prevent us from running a good container
+  if [ -n "${BUILD_CONTAINERS}" ] && is_container_storage_on_s3; then
+    starphleet-s3-put-container "${name}" || true
+  fi
 
-  # At this point the container is active so make it the current container
-  echo "${name}" > "${CURRENT_ORDERS}/${order}/.container"
+  if [ -n "${SERVE_CONTAINERS}" ]; then
+    # At this point the container is active so make it the current container
+    echo "${name}" > "${CURRENT_ORDERS}/${order}/.container"
 
-  # Update this containers status with 'online'
-  echo 'online' > "${STATUS_FILE}"
+    # Update this containers status with 'online'
+    echo 'online' > "${STATUS_FILE}"
 
-  # Announce HUPS in case someone goes crazy
-  echo "HUP_REQUESTED: ${order} ${name}" | logger
-  # Trigger new publish configs and a hup of nginx
-  starphleet-hup-nginx
-  # For good measure
-  exit 0
+    # Announce HUPS in case someone goes crazy
+    echo "HUP_REQUESTED: ${order} ${name}" | logger
+    # Trigger new publish configs and a hup of nginx
+    starphleet-hup-nginx
+    # For good measure
+    exit 0
+  else
+    info Container no longer needed - Reaping
+    starphleet-reaper "${name}" "${order}" --force
+  fi
 fi

--- a/overlay/etc/init/starphleet_serve_order.pre-start
+++ b/overlay/etc/init/starphleet_serve_order.pre-start
@@ -38,6 +38,4 @@ else
   starphleet-lxc-destroy "${name}"
   #build a container, this will recycle any existing container, only building
   #when things are 'new', with a default for said URL to be nothing
-  starphleet-containerize "${SERVICE_GIT_URL:--}" "${name}" "${HEADQUARTERS_LOCAL}/${order}" \
-  || (echo 'building failed' > "${STATUS_FILE}" && exit 1)
 fi

--- a/overlay/etc/starphleet
+++ b/overlay/etc/starphleet
@@ -33,6 +33,8 @@ export MAX_OPEN_FILES="4096"
 if [ "${TERM}" == "unknown" ]; then
   export TERM="xterm-256color"
 fi
+
+
 export SHIP=ship-$(ssh-keygen -lf /etc/ssh/ssh_host_rsa_key.pub | awk '{ print $2; }' | sed -e 's/://g')
 export STARPHLEET_APP_USER="ubuntu"
 export USER_IDENTITY_HEADER="x-identity"
@@ -49,6 +51,17 @@ EC2_DRIVES["/dev/xvdb"]="/var/lib/lxc"
 EC2_DRIVES["/dev/xvdc"]="/var/starphleet"
 EC2_DRIVES["/dev/xvdd"]="/var/log/biglogs"
 EC2_DRIVES["/dev/xvde"]="/var/lib/lxc/data"
+
+##########################################################
+# CONTAINER STORAGE ON S3
+##########################################################
+
+unset SERVE_CONTAINERS
+unset BUILD_CONTAINERS
+unset S3_STORAGE_AWS_ACCESS_KEY_ID
+unset S3_STORAGE_AWS_SECRET_ACCESS_KEY
+unset S3_STORAGE_BUCKET_REGION
+unset S3_STORAGE_BUCKET_NAME
 
 ##########################################################
 # DEVMODE

--- a/scripts/starphleet-containermake
+++ b/scripts/starphleet-containermake
@@ -44,7 +44,9 @@ dev_mode \
 
 #starphleet-base is a create, all orders are a clones to delta0
 cat << EOF > ${CONTAINER_CONF}
-lxc.mount.entry = ${STARPHLEET_ROOT} ${CONTAINER_ROOT}/rootfs${STARPHLEET_ROOT} none bind,${STARPHLEET_ROOT_CONTAINER_PERMISSION} 0 0
+lxc.mount.entry = ${STARPHLEET_ROOT}/buildpacks ${CONTAINER_ROOT}/rootfs${STARPHLEET_ROOT}/buildpacks none bind,${STARPHLEET_ROOT_CONTAINER_PERMISSION} 0 0
+lxc.mount.entry = ${STARPHLEET_ROOT}/private_keys ${CONTAINER_ROOT}/rootfs${STARPHLEET_ROOT}/private_keys none bind,${STARPHLEET_ROOT_CONTAINER_PERMISSION} 0 0
+lxc.mount.entry = ${STARPHLEET_ROOT}/public_keys ${CONTAINER_ROOT}/rootfs${STARPHLEET_ROOT}/public_keys none bind,${STARPHLEET_ROOT_CONTAINER_PERMISSION} 0 0
 lxc.mount.entry = ${ADMIRAL_HOME} ${CONTAINER_ROOT}/rootfs${ADMIRAL_HOME} none defaults,bind,create=dir 0 0
 EOF
 
@@ -74,16 +76,18 @@ else
   SHIP_NAME=$([ -r /etc/starphleet-name ] && $(echo cat /etc/starphleet-name) || echo $(hostname))
 
   starphleet-lxc-destroy ${CONTAINER_NAME}
+
   if [ -z "${base_container_name}" ]; then
     lxc-create --name "${container_name}" -t ubuntu
     CONTAINER_OVERLAY=${CONTAINER_ROOT}/rootfs
+  elif is_container_storage_on_s3 && [ -n "${BUILD_CONTAINERS}" ]; then
+    lxc-clone -B "dir" -o "${base_container_name}" -n "${container_name}"
   else
-    lxc-clone --snapshot -B overlayfs -o "${base_container_name}" -n "${container_name}"
+    lxc-clone --snapshot -B "overlayfs" -o "${base_container_name}" -n "${container_name}"
     CONTAINER_OVERLAY=${CONTAINER_ROOT}/delta0
   fi
 
   echo "lxc.mount.entry = ${STARPHLEET_SHARED_DATA} ${CONTAINER_ROOT}/rootfs/var/data none rbind,rw 0 0" >> ${CONTAINER_CONF}
-
 
   #make a directory where we can mount back to the ship and a config file to mount
   test -d "${CONTAINER_OVERLAY}${STARPHLEET_ROOT}" || mkdir -p "${CONTAINER_OVERLAY}${STARPHLEET_ROOT}"
@@ -93,6 +97,7 @@ else
   mkdir -p "${CONTAINER_OVERLAY}/usr/bin"
   [ -f "/hosthome/.starphleet" ] && cp /hosthome/.starphleet "${CONTAINER_OVERLAY}/.starphleet"
   cp /etc/starphleet "${CONTAINER_OVERLAY}/etc/"
+  rm -rf "${CONTAINER_OVERLAY}/etc/starphleet.d" || true
   cp -r /etc/starphleet.d "${CONTAINER_OVERLAY}/etc/"
   cp /usr/bin/starphleet* "${CONTAINER_OVERLAY}/usr/bin/"
   cp /usr/bin/docopt* "${CONTAINER_OVERLAY}/usr/bin/"
@@ -101,9 +106,46 @@ else
   cp /usr/bin/cronner "${CONTAINER_OVERLAY}/usr/bin/"
   cp /usr/bin/runner "${CONTAINER_OVERLAY}/usr/bin/"
   cp -R ${STARPHLEET_ROOT}/containers/overlay/* ${CONTAINER_OVERLAY}/
+
+  # Persist the HQ inside the container
+  HQ_DEST="${CONTAINER_OVERLAY}${STARPHLEET_ROOT}/headquarters/"
+  mkdir -p "${HQ_DEST}"
+  rsync -ra --exclude="/git" "${STARPHLEET_ROOT}/headquarters/" "${HQ_DEST}"
   #this is the build script for the container itself
   cp "${build_script}" "${CONTAINER_OVERLAY}/build_script"
   chmod +x "${CONTAINER_OVERLAY}/build_script"
+
+  # This code is here as opposed to somewhere else because
+  # we want to compress the container for S3 and/or uncompress it
+  # before all the network setup below
+  if is_container_storage_on_s3; then
+    # If we are expected to build containers and storage is on S3
+    # then we should have a tar.gz of the container on disk or we
+    # haven't made it yet and we should.
+    if [ -n "${BUILD_CONTAINERS}" ] && [ ! -f "${CONTAINER_ROOT}/${CONTAINER_NAME}.tar.gz" ]; then
+      # There are some notes about container portability here:
+      # https://stackoverflow.com/a/34194341
+      echo "Archiving container for S3 - ${CONTAINER_ROOT}/${CONTAINER_NAME}.tar.gz"
+      pushd ${CONTAINER_ROOT}
+      tar --numeric-owner -czvf "${CONTAINER_NAME}.tar.gz" ./*
+      popd
+    fi
+    # The order is important here.  A machine configured to serve & build
+    # containers shouldn't go fetch containers on S3 because the containers
+    # _should_ be generated locally.  Thus, we perform the check for
+    # retreiving containers after the archive above.
+    if [ -n "${SERVE_CONTAINERS}" ] \
+      && [ ! -f "${CONTAINER_ROOT}/${CONTAINER_NAME}.tar.gz" ] \
+      && [ ! -d "${CONTAINER_ROOT}" ]; then
+
+      mkdir -p "${CONTAINER_ROOT}"
+      pushd "${CONTAINER_ROOT}"
+      starphleet-s3-get-container "${CONTAINER_NAME}"
+      tar --numeric-owner -xzvf "${CONTAINER_ROOT}/${CONTAINER_NAME}.tar.gz"
+      popd
+
+    fi
+  fi
 
   #start up the container, waiting for the network, and then run the container build script
   lxc-start --name ${CONTAINER_NAME} -d

--- a/scripts/starphleet-s3-container-exists
+++ b/scripts/starphleet-s3-container-exists
@@ -1,0 +1,28 @@
+#!/usr/bin/env starphleet-launcher
+### Usage:
+###    starphleet-s3-container-exists <name> 
+###
+### Fuzzy match and make attaching to instances easier
+die_on_error
+run_as_root_or_die
+
+s3://glg-starphleet-containers
+# Make sure they pass 'something' to search for
+
+# For notes
+# if [ -n "${BUILD_CONTAINERS}" ] && is_container_storage_on_s3; then
+#   starphleet-s3-put-container "${name}" "${S3_PATH_FOR_CONTAINER_STORAGE}" || true
+# fi
+
+aws s3 ls "${S3_PATH_FOR_CONTAINER_STORAGE}/${name}.tar.gz"
+
+# Check and make sure there's at least one running container
+CONTAINERS=$(lxc-ls -f | grep STOPPED | grep ${service} | awk '{print $1}')
+[ -z "${CONTAINERS}" ] && echo No Stopped Containers && exit 1
+
+# Now figure out which container they want and attach
+echo "Start which instance:"
+select container in $(lxc-ls -f | grep STOPPED | grep ${service} | awk '{print $1}'); do
+  [ ! -z ${container} ] && sudo lxc-start -d -n "${container}"
+  break;
+done

--- a/scripts/starphleet-s3-get-container
+++ b/scripts/starphleet-s3-get-container
@@ -1,0 +1,26 @@
+#!/usr/bin/env starphleet-launcher
+### Usage:
+###    starphleet-s3-get-container <name>
+###
+### Fuzzy match and make attaching to instances easier
+die_on_error
+run_as_root_or_die
+
+# Make sure they pass 'something' to search for
+[ -z "${name}" ] && echo Please pass the name of a container && exit 1
+
+aws s3 cp "${S3_PATH_FOR_CONTAINER_STORAGE}/${name}.tar.gz" "/var/lib/lxc/"
+
+sudo lxc-clone -KH -B dir -o epistream-jwt-d171215-d030728 -n test
+
+
+# Check and make sure there's at least one running container
+CONTAINERS=$(lxc-ls -f | grep STOPPED | grep ${service} | awk '{print $1}')
+[ -z "${CONTAINERS}" ] && echo No Stopped Containers && exit 1
+
+# Now figure out which container they want and attach
+echo "Start which instance:"
+select container in $(lxc-ls -f | grep STOPPED | grep ${service} | awk '{print $1}'); do
+  [ ! -z ${container} ] && sudo lxc-start -d -n "${container}"
+  break;
+done

--- a/scripts/starphleet-s3-put-container
+++ b/scripts/starphleet-s3-put-container
@@ -1,0 +1,32 @@
+#!/usr/bin/env starphleet-launcher
+### Usage:
+###    starphleet-s3-put-container <service>
+###
+### Fuzzy match and make attaching to instances easier
+die_on_error
+run_as_root_or_die
+
+# For notes
+# if [ -n "${BUILD_CONTAINERS}" ] && is_container_storage_on_s3; then
+#   starphleet-s3-put-container "${name}" "${S3_PATH_FOR_CONTAINER_STORAGE}" || true
+# fi
+
+# Container must be stopped to get a good clone
+lxc-stop -n "${service}"
+# Clone the container to 'merge' overlayfs with delta
+lxc-clone -KH -B dir -o epistream-jwt-d171215-d030728 -n test
+
+
+# Make sure they pass 'something' to search for
+[ -z "${service}" ] && echo Please pass the name of a container && exit 1
+
+# Check and make sure there's at least one running container
+CONTAINERS=$(lxc-ls -f | grep STOPPED | grep ${service} | awk '{print $1}')
+[ -z "${CONTAINERS}" ] && echo No Stopped Containers && exit 1
+
+# Now figure out which container they want and attach
+echo "Start which instance:"
+select container in $(lxc-ls -f | grep STOPPED | grep ${service} | awk '{print $1}'); do
+  [ ! -z ${container} ] && sudo lxc-start -d -n "${container}"
+  break;
+done

--- a/scripts/tools
+++ b/scripts/tools
@@ -105,6 +105,14 @@ function expose() {
   true
 }
 
+# In bash, the return values are odd.  Exiting with a Zero
+# means you didn't have a problem.
+#
+# See:  http://glg.link/Ea8zjA
+export TRUE=0;
+export FALSE=1;
+
+
 # All the rules that surround the supported security measures
 # for starphleet.  For instance, if a certain security feature
 # has constraints, needs certain settings or files, or needs various
@@ -114,12 +122,6 @@ function expose() {
 # security measure something is wrong.
 function validate_security() {
 
-  # In bash, the return values are odd.  Exiting with a Zero
-  # means you didn't have a problem.
-  #
-  # See:  http://glg.link/Ea8zjA
-  TRUE=0;
-  FALSE=1;
   # SECURITY_MODE is set in the default starphleet config.  If it gets unset
   # something went wrong so let the user know
   if ! echo "${SECURITY_MODE}" | egrep 'htpasswd|jwt|ldap|public' > /dev/null; then
@@ -310,6 +312,10 @@ function dev_mode() {
   else
     false
   fi
+}
+
+function is_container_storage_on_s3() {
+  return "${FALSE}"
 }
 
 function run_as_root_or_die(){


### PR DESCRIPTION
### Summary 

Enable the ability to store and replay containers from S3 as opposed to dynamically building containers  on the same machine.

### Details

Migrating to a system that allows containers to be stored on S3 and replayed on any machine.  Changes include:

- [ ] Persisting the HQ in containers instead of mounting the HQ in the LXC config
- [ ] Making containermake aware of S3
- [ ] Uploading containers to S3 after the Healthcheck
- [ ] Allowing a machine to be in three modes:  serve, build, or both
- [ ] Handling serving containers of 'last known good' when guids don't align
- [ ] Things I haven't figured out yet