### PR TITLE
Delimit tags with double brackets for easier log parsing

### DIFF
--- a/scripts/cronner
+++ b/scripts/cronner
@@ -19,7 +19,7 @@ do
       echo 'MAILTO=""' >> "${HOME}/sh_at"
       started="true"
     fi
-    echo "${SH_AT}" runner "${app_root}" "${orders}" "${file} 2>&1 | logger -t '$(basename ${orders_dir})'" >> "${HOME}/sh_at"
+    echo "${SH_AT}" runner "${app_root}" "${orders}" "${file} 2>&1 | logger -t '{{$(basename ${orders_dir})}}'" >> "${HOME}/sh_at"
   fi
 done
 if [ -f "${HOME}/sh_at" ]; then

--- a/scripts/runner
+++ b/scripts/runner
@@ -19,5 +19,5 @@ if [ $? -ne 0 ]; then
   exit 0
 fi
 
-2>&1 ${script} | logger --stderr -t "$(basename ${script})"
+2>&1 ${script} | logger --stderr -t "{{$(basename ${script})}}"
 ) 200>/var/lock/${SHASUM}


### PR DESCRIPTION
Adding double brackets around log tags for jobs.  This will make it easier to pullout service name and job name, as well as to ignore log entries that are duplicates or irrelevant.