### PR TITLE
Bug: New Versions of LXC need lxc-attach -L option

### DIFF
--- a/scripts/starphleet-containermake
+++ b/scripts/starphleet-containermake
@@ -108,21 +108,41 @@ else
   #start up the container, waiting for the network, and then run the container build script
   lxc-start --name ${CONTAINER_NAME} -d
   starphleet-lxc-wait ${CONTAINER_NAME} RUNNING
-  lxc-attach --name ${CONTAINER_NAME} -- bash starphleet-wait-network
+
+  # On LXC >= 1.0.10 - lxc-attach no longer attaches to STDOUT when run
+  # from upstart.  They changed how pty assignments are handled.
+  # From the new docs:
+  #
+  #     -L, --pty-log file
+  #        Specify a file where the output of lxc-attach will be logged.
+  #
+  #        Important: When a standard file descriptor does not refer to
+  #        a pty output produced on it will not be logged.
+  #
+  #  See more here:  http://glg.link/vQpIdw
+  #
+  #  At some point, this check should go away and we should instead have
+  #  this be the default behavior (when all machines are upgraded)
+  LXC_VERSION="$(dpkg -l | egrep 'ii  lxc ' | awk '{print $3}' | cut -f 1 -d '-')"
+  if [ "${LXC_VERSION}" = "1.0.10" ]; then
+    VERSION_1_0_10_OPTION="-L /dev/stdout"
+  fi
+
+  lxc-attach --name ${CONTAINER_NAME} ${VERSION_1_0_10_OPTION} -- bash starphleet-wait-network
   #host file updates
   bridge_ip
-  lxc-attach --name ${CONTAINER_NAME} -- bash -c "echo -e '\n${BRIDGE_IP}  localship' >> /etc/hosts"
-  lxc-attach --name ${CONTAINER_NAME} -- bash -c "printf '\nexport SHIP_NAME=%s\n' ${SHIP_NAME} >> /usr/bin/tools"
-  lxc-attach --name ${CONTAINER_NAME} -- bash -c "echo -e '\n127.0.0.1  $(< /etc/hostname)' >> /etc/hosts"
-  lxc-attach --name ${CONTAINER_NAME} -- bash -c "echo -e '\n127.0.0.1  ${CONTAINER_NAME}' >> /etc/hosts"
+  lxc-attach --name ${CONTAINER_NAME} ${VERSION_1_0_10_OPTION} -- bash -c "echo -e '\n${BRIDGE_IP}  localship' >> /etc/hosts"
+  lxc-attach --name ${CONTAINER_NAME} ${VERSION_1_0_10_OPTION} -- bash -c "printf '\nexport SHIP_NAME=%s\n' ${SHIP_NAME} >> /usr/bin/tools"
+  lxc-attach --name ${CONTAINER_NAME} ${VERSION_1_0_10_OPTION} -- bash -c "echo -e '\n127.0.0.1  $(< /etc/hostname)' >> /etc/hosts"
+  lxc-attach --name ${CONTAINER_NAME} ${VERSION_1_0_10_OPTION} -- bash -c "echo -e '\n127.0.0.1  ${CONTAINER_NAME}' >> /etc/hosts"
 
-  lxc-attach --name ${CONTAINER_NAME} -- bash -c 'chmod 777 /var/log/'
-  lxc-attach --name ${CONTAINER_NAME} -- bash -c 'useradd -s /bin/bash ${ADMIRAL} || true'
-  lxc-attach --name ${CONTAINER_NAME} -- bash -c 'adduser ${ADMIRAL} sudo'
-  lxc-attach --name ${CONTAINER_NAME} -- bash -c 'chown -R ${ADMIRAL}:${ADMIRAL} ${ADMIRAL_HOME}/.ssh'
-  lxc-attach --name ${CONTAINER_NAME} -- bash -c 'echo -e "\n${ADMIRAL} ALL=NOPASSWD:ALL" >> /etc/sudoers'
-  lxc-attach --name ${CONTAINER_NAME} -- bash -c 'echo -e "\n${STARPHLEET_APP_USER} ALL=NOPASSWD:ALL" >> /etc/sudoers'
-  lxc-attach --name ${CONTAINER_NAME} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "source /usr/bin/tools; /build_script"
+  lxc-attach --name ${CONTAINER_NAME} ${VERSION_1_0_10_OPTION} -- bash -c 'chmod 777 /var/log/'
+  lxc-attach --name ${CONTAINER_NAME} ${VERSION_1_0_10_OPTION} -- bash -c 'useradd -s /bin/bash ${ADMIRAL} || true'
+  lxc-attach --name ${CONTAINER_NAME} ${VERSION_1_0_10_OPTION} -- bash -c 'adduser ${ADMIRAL} sudo'
+  lxc-attach --name ${CONTAINER_NAME} ${VERSION_1_0_10_OPTION} -- bash -c 'chown -R ${ADMIRAL}:${ADMIRAL} ${ADMIRAL_HOME}/.ssh'
+  lxc-attach --name ${CONTAINER_NAME} ${VERSION_1_0_10_OPTION} -- bash -c 'echo -e "\n${ADMIRAL} ALL=NOPASSWD:ALL" >> /etc/sudoers'
+  lxc-attach --name ${CONTAINER_NAME} ${VERSION_1_0_10_OPTION} -- bash -c 'echo -e "\n${STARPHLEET_APP_USER} ALL=NOPASSWD:ALL" >> /etc/sudoers'
+  lxc-attach --name ${CONTAINER_NAME} ${VERSION_1_0_10_OPTION} -- sudo -H -u ${STARPHLEET_APP_USER} bash -c "source /usr/bin/tools; /build_script"
 
   if [ "${run}" == "true" ]; then
     info leaving ${CONTAINER_NAME} running


### PR DESCRIPTION
- New versions of LXC do not handle PTY assignments the same
  and you need to explicitly specify you want output handed
  to stdout when running from upstart