### PR TITLE
Add secrets

### DIFF
--- a/overlay/etc/starphleet
+++ b/overlay/etc/starphleet
@@ -97,3 +97,10 @@ unset JWT_EXPIRATION_IN_SECONDS
 unset JWT_MAX_TOKEN_AGE_IN_SECONDS
 # HTPASSWD Needs
 unset HTPASSWD
+
+##########################################################
+# Secrets Service In AWS
+##########################################################
+unset AWS_SECRETS_DEFAULT_REGION
+unset AWS_SECRETS_AWS_ACCESS_KEY_ID
+unset AWS_SECRETS_AWS_SECRET_ACCESS_KEY

--- a/overlay/etc/starphleet
+++ b/overlay/etc/starphleet
@@ -97,10 +97,3 @@ unset JWT_EXPIRATION_IN_SECONDS
 unset JWT_MAX_TOKEN_AGE_IN_SECONDS
 # HTPASSWD Needs
 unset HTPASSWD
-
-##########################################################
-# Secrets Service In AWS
-##########################################################
-unset AWS_SECRETS_DEFAULT_REGION
-unset AWS_SECRETS_AWS_ACCESS_KEY_ID
-unset AWS_SECRETS_AWS_SECRET_ACCESS_KEY

--- a/overlay/var/starphleet/containers/starphleet-base
+++ b/overlay/var/starphleet/containers/starphleet-base
@@ -44,6 +44,11 @@ sqlite3
 telnet
 zlib1g-dev
 bsdmainutils
+groff
+libyaml-dev
+python-dev
+python-docutils
+python-pip
 FFF
 )
 
@@ -55,23 +60,18 @@ FFF
 ## at a later date.  This may be removable when support for Ubuntu 14.04
 ## is deprecated.
 set +e
-# New pip install wanted libyaml so we'll install that before trying
-# to get the latest AWS cli
-apt-get update -y
-apt-get install -y libyaml-dev python-dev python-docutils python-pip
-#######
 ## Because:  https://github.com/aws/aws-cli/issues/2999#issuecomment-356019306
-pip uninstall boto3 -y
-pip uninstall boto -y
-pip uninstall botocore -y
+sudo pip uninstall boto3 -y
+sudo pip uninstall boto -y
+sudo pip uninstall botocore -y
 # Fix bug caused by apt/ubuntu
-rm -rf /usr/local/lib/python2.7/dist-packages/botocore-*.dist-info
-pip install botocore --force-reinstall --upgrade
+sudo rm -rf /usr/local/lib/python2.7/dist-packages/botocore-*.dist-info
+sudo pip install botocore --force-reinstall --upgrade
 #######
 ## Because: https://github.com/aws/aws-cli/issues/3007#issuecomment-350797161
-pip install --upgrade s3transfer
-rm -rf /tmp/pip_build_root/PyYAML
-pip install awscli --force-reinstall --upgrade
+sudo pip install --upgrade s3transfer
+sudo rm -rf /tmp/pip_build_root/PyYAML
+sudo pip install awscli --force-reinstall --upgrade
 set -e
 
 #ruby superstition

--- a/overlay/var/starphleet/containers/starphleet-base
+++ b/overlay/var/starphleet/containers/starphleet-base
@@ -47,6 +47,33 @@ bsdmainutils
 FFF
 )
 
+
+## This is a working set of steps as of Oct 1, 2018 to get a modern
+## version of the AWS Cli running on Ubuntu 14.04.  Every few months
+## the endzone moves and upstream complications add complexity to the
+## process.  As such, it's possible this will need more adjustments
+## at a later date.  This may be removable when support for Ubuntu 14.04
+## is deprecated.
+set +e
+# New pip install wanted libyaml so we'll install that before trying
+# to get the latest AWS cli
+apt-get update -y
+apt-get install -y libyaml-dev python-dev python-docutils python-pip
+#######
+## Because:  https://github.com/aws/aws-cli/issues/2999#issuecomment-356019306
+pip uninstall boto3 -y
+pip uninstall boto -y
+pip uninstall botocore -y
+# Fix bug caused by apt/ubuntu
+rm -rf /usr/local/lib/python2.7/dist-packages/botocore-*.dist-info
+pip install botocore --force-reinstall --upgrade
+#######
+## Because: https://github.com/aws/aws-cli/issues/3007#issuecomment-350797161
+pip install --upgrade s3transfer
+rm -rf /tmp/pip_build_root/PyYAML
+pip install awscli --force-reinstall --upgrade
+set -e
+
 #ruby superstition
 export HOME=/
 sudo gem install bundler

--- a/scripts/tools
+++ b/scripts/tools
@@ -360,10 +360,28 @@ function dev_mode() {
   fi
 }
 
+# Usage - fromJson "somejsonstring" "somekey"
+function fromJson() {
+    python -c \
+"import json
+import sys
+
+json_string, json_key = sys.argv[1:]
+try:
+    print json.loads(json_string)[json_key]
+except Exception:
+    print \"This isn't json!\"" \
+    "${1}" "${2}"
+}
+
+function getRegionFromInstanceMetadata() {
+    AZ=$(curl http://169.254.169.254/latest/meta-data/placement/availability-zone)
+    echo ${AZ::-1}
+}
+
 function secrets() {
   # Not necessary but more readable
   KEY_NAME_IN_AWS_SECRETS="${1}"
-  KEY_NAME_IN_THE_VALUE_OF_THE_SECRET="${2}"
   # Our default behavior should be to not run outside a container.  Orders
   # files are evaluated constantly by Starphleet and there is no reason to
   # add additional burden or calls to a secrets service until we actually need
@@ -383,27 +401,36 @@ function secrets() {
     return
   fi
 
+  AWS_DEFAULT_REGION="$(aws configure get region)"
+
+  # If we failed to get the region from the previous call or
+  # it came back blank for some reason, fetch the instance metadata
+  # from AWS' own instance metadata service directly.
+  if [ $? -ne 1 ] || [ -z "$AWS_DEFAULT_REGION" ]; then
+    AWS_DEFAULT_REGION="$(getRegionFromInstanceMetadata)"
+  fi
+
   # Our Default Should be developmentkeys
-  KEY_PREFIX="${AWS_SECRETS_AWS_DEFAULT_REGION}/developmentkeys/"
+  KEY_PREFIX="${AWS_DEFAULT_REGION}/developmentkeys/"
 
   # ...but, some list of conditions lead us towards production keys
   # TODO: The list?
   if [ "${NODE_ENV}" == "production" ]; then
-    KEY_PREFIX="${AWS_SECRETS_AWS_DEFAULT_REGION}/productionkeys/"
+    KEY_PREFIX="${AWS_DEFAULT_REGION}/productionkeys/"
   fi
 
   # Get the key
   #  - redirect stderr since aws cli is whining lately - but, we keep errors just-in-case
   #  - parse with python (jq isn't modern by default in old Ubuntu)
   #  - Return 'something' on failure
-  AWS_DEFAULT_REGION="${AWS_SECRETS_AWS_DEFAULT_REGION}" \
-  AWS_ACCESS_KEY_ID="${AWS_SECRETS_AWS_ACCESS_KEY_ID}" \
-  AWS_SECRET_ACCESS_KEY="${AWS_SECRETS_AWS_SECRET_ACCESS_KEY}" \
-  eval aws secretsmanager get-secret-value --secret-id "${KEY_PREFIX}${KEY_NAME_IN_AWS_SECRETS}" \
-    2> /tmp/.$$.aws_secrets_error.log \
-    | python -c 'import sys, json; print json.loads(json.load(sys.stdin)["SecretString"])["'${KEY_NAME_IN_THE_VALUE_OF_THE_SECRET}'"]' \
-    || echo "AWS Command Broke"
+  # echo "Test thing"
+  # echo "$(echo $AWS_DEFAULT_REGION)"
 
+  RAW_SECRET=$(AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION}" aws secretsmanager get-secret-value --secret-id "${KEY_PREFIX}${KEY_NAME_IN_AWS_SECRETS}")
+  fromJson "$RAW_SECRET" SecretString
+    # 2> /tmp/.$$.aws_secrets_error.log \
+    # | python -c 'import sys, json; print json.load(sys.stdin)["SecretString"]' \
+    # || echo "AWS Command Broke"
 }
 
 # Provide a way for scripts to easily detect if this

--- a/scripts/tools
+++ b/scripts/tools
@@ -375,7 +375,7 @@ except Exception:
 }
 
 function getRegionFromInstanceMetadata() {
-    AZ=$(curl --connect-timeout 2 http://169.254.169.254/latest/meta-data/placement/availability-zone)
+    AZ=$(curl --connect-timeout 10 http://169.254.169.254/latest/meta-data/placement/availability-zone)
     echo ${AZ::-1}
 }
 
@@ -387,7 +387,7 @@ function secrets() {
   # add additional burden or calls to a secrets service until we actually need
   # the secrets - which, is when the orders file is run within a container
   if [ -z "${ORDERS_NAME}" ]; then
-    echo Running Outside Container
+    (>&2 echo "Running Outside Container")
     return
   fi
 
@@ -397,7 +397,7 @@ function secrets() {
   #       secrets.  We will never support anything older than
   #       Ubuntu 14.04
   if ! which aws > /dev/null; then
-    echo Missing Requirements
+    (>&2 echo "Missing Requirements")
     return
   fi
 

--- a/scripts/tools
+++ b/scripts/tools
@@ -375,7 +375,7 @@ except Exception:
 }
 
 function getRegionFromInstanceMetadata() {
-    AZ=$(curl http://169.254.169.254/latest/meta-data/placement/availability-zone)
+    AZ=$(curl --connect-timeout 2 http://169.254.169.254/latest/meta-data/placement/availability-zone)
     echo ${AZ::-1}
 }
 

--- a/scripts/tools
+++ b/scripts/tools
@@ -370,7 +370,7 @@ json_string, json_key = sys.argv[1:]
 try:
     print json.loads(json_string)[json_key]
 except Exception:
-    print \"This isn't json!\"" \
+    print >> sys.stderr, \"This isn't json!\"" \
     "${1}" "${2}"
 }
 

--- a/scripts/tools
+++ b/scripts/tools
@@ -360,6 +360,52 @@ function dev_mode() {
   fi
 }
 
+function secrets() {
+  # Not necessary but more readable
+  KEY_NAME_IN_AWS_SECRETS="${1}"
+  KEY_NAME_IN_THE_VALUE_OF_THE_SECRET="${2}"
+  # Our default behavior should be to not run outside a container.  Orders
+  # files are evaluated constantly by Starphleet and there is no reason to
+  # add additional burden or calls to a secrets service until we actually need
+  # the secrets - which, is when the orders file is run within a container
+  if [ -z "${ORDERS_NAME}" ]; then
+    echo Running Outside Container
+    return
+  fi
+
+  # If we don't have an aws command we have nothing.
+  # TODO: Do we need a version check here?  We need to check if
+  #       the default aws command from Ubuntu 14.04LTS supports
+  #       secrets.  We will never support anything older than
+  #       Ubuntu 14.04
+  if ! which aws > /dev/null; then
+    echo Missing Requirements
+    return
+  fi
+
+  # Our Default Should be developmentkeys
+  KEY_PREFIX="${AWS_DEFAULT_REGION}/developmentkeys/"
+
+  # ...but, some list of conditions lead us towards production keys
+  # TODO: The list?
+  if [ "${NODE_ENV}" == "production" ]; then
+    KEY_PREFIX="${AWS_DEFAULT_REGION}/productionkeys/"
+  fi
+
+  # Get the key
+  #  - redirect stderr since aws cli is whining lately - but, we keep errors just-in-case
+  #  - parse with python (jq isn't modern by default in old Ubuntu)
+  #  - Return 'something' on failure
+  AWS_DEFAULT_REGION="${AWS_SECRETS_DEFAULT_REGION}" \
+  AWS_ACCESS_KEY_ID="${AWS_SECRETS_AWS_ACCESS_KEY_ID}" \
+  AWS_SECRET_ACCESS_KEY="${AWS_SECRETS_AWS_SECRET_ACCESS_KEY}" \
+  eval aws secretsmanager get-secret-value --secret-id "${KEY_PREFIX}${KEY_NAME_IN_AWS_SECRETS}" \
+    2> /tmp/.$$.aws_secrets_error.log \
+    | python -c 'import sys, json; print json.loads(json.load(sys.stdin)["SecretString"])["'${KEY_NAME_IN_THE_VALUE_OF_THE_SECRET}'"]' \
+    || echo "AWS Command Broke"
+
+}
+
 # Provide a way for scripts to easily detect if this
 # starphleet instance is storing the containers on S3.
 function is_container_storage_on_s3() {

--- a/scripts/tools
+++ b/scripts/tools
@@ -420,17 +420,8 @@ function secrets() {
   fi
 
   # Get the key
-  #  - redirect stderr since aws cli is whining lately - but, we keep errors just-in-case
-  #  - parse with python (jq isn't modern by default in old Ubuntu)
-  #  - Return 'something' on failure
-  # echo "Test thing"
-  # echo "$(echo $AWS_DEFAULT_REGION)"
-
   RAW_SECRET=$(AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION}" aws secretsmanager get-secret-value --secret-id "${KEY_PREFIX}${KEY_NAME_IN_AWS_SECRETS}")
   fromJson "$RAW_SECRET" SecretString
-    # 2> /tmp/.$$.aws_secrets_error.log \
-    # | python -c 'import sys, json; print json.load(sys.stdin)["SecretString"]' \
-    # || echo "AWS Command Broke"
 }
 
 # Provide a way for scripts to easily detect if this

--- a/scripts/tools
+++ b/scripts/tools
@@ -384,19 +384,19 @@ function secrets() {
   fi
 
   # Our Default Should be developmentkeys
-  KEY_PREFIX="${AWS_DEFAULT_REGION}/developmentkeys/"
+  KEY_PREFIX="${AWS_SECRETS_AWS_DEFAULT_REGION}/developmentkeys/"
 
   # ...but, some list of conditions lead us towards production keys
   # TODO: The list?
   if [ "${NODE_ENV}" == "production" ]; then
-    KEY_PREFIX="${AWS_DEFAULT_REGION}/productionkeys/"
+    KEY_PREFIX="${AWS_SECRETS_AWS_DEFAULT_REGION}/productionkeys/"
   fi
 
   # Get the key
   #  - redirect stderr since aws cli is whining lately - but, we keep errors just-in-case
   #  - parse with python (jq isn't modern by default in old Ubuntu)
   #  - Return 'something' on failure
-  AWS_DEFAULT_REGION="${AWS_SECRETS_DEFAULT_REGION}" \
+  AWS_DEFAULT_REGION="${AWS_SECRETS_AWS_DEFAULT_REGION}" \
   AWS_ACCESS_KEY_ID="${AWS_SECRETS_AWS_ACCESS_KEY_ID}" \
   AWS_SECRET_ACCESS_KEY="${AWS_SECRETS_AWS_SECRET_ACCESS_KEY}" \
   eval aws secretsmanager get-secret-value --secret-id "${KEY_PREFIX}${KEY_NAME_IN_AWS_SECRETS}" \


### PR DESCRIPTION
This builds on the `secrets` function provided by @bhudgens. We have created a function `fromJson` that handles extracting one field from a json object, rather than having that functionality directly inside of `secrets`. This allows us to conveniently request a whole secret, and then assign its components to different env variables.

Usage:
```shell
fromJson '{"somekey": "somevalue"}' somekey
# prints somevalue
```

This is pretty similar to `jq`, except much less complex/complete, and has no dependencies beyond bash and python

We also wrote a function to get region from instance metadata if it can't be found in env or ~/.aws

Usage:
```shell
getRegionFromInstanceMetadata
# prints the region, i.e. us-east-1
```

So, all together, usage of secrets looks like:

```shell
SMASH_SECRET=$(secrets SMASH)

export SMASH="{\"driver\":\"mssql\",\"name\":\"smash\",\"config\":{\"server\":\"$(fromJson $SMASH_SECRET 'host')\",\"password\":\"$(fromJson $SMASH_SECRET 'password')\",\"userName\":\"$(fromJson $SMASH_SECRET 'username')\",\"options\":{\"port\":$(fromJson $SMASH_SECRET 'port')}}}"
```