### PR TITLE
Remove old installation of awscli.

### DIFF
--- a/overlay/var/starphleet/containers/starphleet-base
+++ b/overlay/var/starphleet/containers/starphleet-base
@@ -3,7 +3,6 @@
 sudo apt-get -y update
 sudo apt-get install -y --force-yes $(cat << FFF
 autoconf
-awscli
 bind9-host
 bison
 build-essential

--- a/scripts/tools
+++ b/scripts/tools
@@ -375,7 +375,7 @@ except Exception:
 }
 
 function getRegionFromInstanceMetadata() {
-    AZ=$(curl --connect-timeout 10 http://169.254.169.254/latest/meta-data/placement/availability-zone)
+    AZ=$(curl -s --connect-timeout 10 http://169.254.169.254/latest/meta-data/placement/availability-zone)
     echo ${AZ::-1}
 }
 


### PR DESCRIPTION
Installs a super old version that isn't useful given that the base
container later installs a newer version via pip anyway. Worse, it can
cause path conflicts -- just get rid of it.

Additionally, silence the curl command in getRegionFromInstanceMetadata
to appease Ben. Also, it's just nice.