### PR TITLE
caches region from instance metadata, update aws-cli

### DIFF
--- a/overlay/var/starphleet/containers/starphleet-base
+++ b/overlay/var/starphleet/containers/starphleet-base
@@ -15,7 +15,6 @@ imagemagick
 iputils-tracepath
 libcurl4-openssl-dev
 libevent-dev
-libffi-dev
 libglib2.0-dev
 libjpeg-dev
 libjpeg62

--- a/overlay/var/starphleet/containers/starphleet-base
+++ b/overlay/var/starphleet/containers/starphleet-base
@@ -15,6 +15,7 @@ imagemagick
 iputils-tracepath
 libcurl4-openssl-dev
 libevent-dev
+libffi-dev
 libglib2.0-dev
 libjpeg-dev
 libjpeg62
@@ -51,8 +52,9 @@ python-pip
 FFF
 )
 
+sudo apt-get remove awscli --assume-yes
 
-## This is a working set of steps as of Oct 1, 2018 to get a modern
+## This is a working set of steps as of Nov 1, 2018 to get a modern
 ## version of the AWS Cli running on Ubuntu 14.04.  Every few months
 ## the endzone moves and upstream complications add complexity to the
 ## process.  As such, it's possible this will need more adjustments

--- a/overlay/var/starphleet/containers/starphleet-base
+++ b/overlay/var/starphleet/containers/starphleet-base
@@ -51,8 +51,6 @@ python-pip
 FFF
 )
 
-sudo apt-get remove awscli --assume-yes
-
 ## This is a working set of steps as of Nov 1, 2018 to get a modern
 ## version of the AWS Cli running on Ubuntu 14.04.  Every few months
 ## the endzone moves and upstream complications add complexity to the
@@ -61,6 +59,7 @@ sudo apt-get remove awscli --assume-yes
 ## is deprecated.
 set +e
 ## Because:  https://github.com/aws/aws-cli/issues/2999#issuecomment-356019306
+sudo apt-get remove awscli --assume-yes
 sudo pip uninstall boto3 -y
 sudo pip uninstall boto -y
 sudo pip uninstall botocore -y

--- a/scripts/tools
+++ b/scripts/tools
@@ -375,8 +375,12 @@ except Exception:
 }
 
 function getRegionFromInstanceMetadata() {
-    AZ=$(curl -s --connect-timeout 10 http://169.254.169.254/latest/meta-data/placement/availability-zone)
-    echo ${AZ::-1}
+  if [ -z "$AWS_DEFAULT_REGION" ]; then
+    AZ=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
+    export AWS_DEFAULT_REGION=${AZ::-1}
+  fi
+
+  echo $AWS_DEFAULT_REGION
 }
 
 function secrets() {

--- a/scripts/tools
+++ b/scripts/tools
@@ -374,15 +374,6 @@ except Exception:
     "${1}" "${2}"
 }
 
-function getRegionFromInstanceMetadata() {
-  if [ -z "$AWS_DEFAULT_REGION" ]; then
-    AZ=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
-    export AWS_DEFAULT_REGION=${AZ::-1}
-  fi
-
-  echo $AWS_DEFAULT_REGION
-}
-
 function secrets() {
   # Not necessary but more readable
   KEY_NAME_IN_AWS_SECRETS="${1}"
@@ -411,7 +402,7 @@ function secrets() {
   # it came back blank for some reason, fetch the instance metadata
   # from AWS' own instance metadata service directly.
   if [ $? -ne 1 ] || [ -z "$AWS_DEFAULT_REGION" ]; then
-    AWS_DEFAULT_REGION="$(getRegionFromInstanceMetadata)"
+    AWS_DEFAULT_REGION=${STARPHLEET_EC2_REGION::-1}
   fi
 
   # Our Default Should be developmentkeys


### PR DESCRIPTION
This makes a minor change regarding caching the AWS region the first time we request it, as opposed to requesting it for every single secrets retrieval. The prior behavior resulted in occasionally not getting the region, and then failing subsequent requests. This has been tested on a dev ship.