### PR TITLE
Base container build

### DIFF
--- a/overlay/etc/init/starphleet.pre-start
+++ b/overlay/etc/init/starphleet.pre-start
@@ -16,7 +16,7 @@ set-starphleet-env-from-user-data
 # We don't need a base container on ships that only "serve" containers from s3.
 if is_container_storage_on_s3 \
   && [ -z "${BUILD_CONTAINERS}" ] \
-  && [ -n "${SERVE_CONTAINERS}"]; then
+  && [ -n "${SERVE_CONTAINERS}" ]; then
   exit 0
 fi
 (sudo lxc-ls | grep starphleet-base) || sudo starphleet-build-base-container

--- a/overlay/etc/init/starphleet.pre-start
+++ b/overlay/etc/init/starphleet.pre-start
@@ -13,6 +13,8 @@ mount-block-devices
 move-syslog-to-biglogs
 set-starphleet-hq-from-userdata
 set-starphleet-env-from-user-data
+# We just set the environment, so we need to load it again
+source `which tools`
 # We don't need a base container on ships that only "serve" containers from s3.
 if is_container_storage_on_s3 \
   && [ -z "${BUILD_CONTAINERS}" ] \

--- a/overlay/etc/init/starphleet.pre-start
+++ b/overlay/etc/init/starphleet.pre-start
@@ -11,6 +11,12 @@ echo INTERNAL_HOST=\"${LOCAL_IP}\" > /etc/starphleet.d/internal_host
 source `which tools`
 mount-block-devices
 move-syslog-to-biglogs
-(sudo lxc-ls | grep starphleet-base) || sudo starphleet-build-base-container
 set-starphleet-hq-from-userdata
 set-starphleet-env-from-user-data
+# We don't need a base container on ships that only "serve" containers from s3.
+if is_container_storage_on_s3 \
+  && [ -z "${BUILD_CONTAINERS}" ] \
+  && [ -n "${SERVE_CONTAINERS}"]; then
+  exit 0
+fi
+(sudo lxc-ls | grep starphleet-base) || sudo starphleet-build-base-container


### PR DESCRIPTION
Only build the base container when we need to. 

This checks for the env vars for s3 container storage, and if the ship is only serving containers, will skip the build.

Tested in multiple scenarios.
1. Userdata included variables for a "serve only" server, where the containers are all pulled from s3.
2. Userdata included variables marking the server as a "build" server.
3. Userdata had no related variables.

In the first case, it skipped the build as we intended. In tests 2 and 3, the base-container built as expected. 