### PR TITLE
Download latest secrets binary in starphleet-containerize

### DIFF
--- a/scripts/starphleet-containerize
+++ b/scripts/starphleet-containerize
@@ -51,6 +51,13 @@ echo "ssh -F /tmp/gitsshconfig \$@" > /tmp/gitssh
 chmod +x /tmp/gitssh
 EOF
 
+#Downloads the latest secrets binary
+cat << 'EOF' >> ${CONTAINER_BUILD_SCRIPT}
+trace Downloading latest secrets binary
+sudo aws s3 cp s3://glg-deployment-packages/secrets /usr/bin/secrets
+sudo chmod +x /usr/bin/secrets
+EOF
+
 #now -- this is escaped, lots of variables included from this script
 cat << EOF >> ${CONTAINER_BUILD_SCRIPT}
 


### PR DESCRIPTION
This fixes glg/secrets#20.

Now, starphleet will fetch the latest secrets binary from s3 each time it builds a new container, and not just in the base container. This finishes out the ci/cd pipeline such that all new containers will always be running whatever is in `master` in glg/secrets.  

This was tested on @drhayes devship.