### PR TITLE
Remove nobootwait fstab option

### DIFF
--- a/scripts/mount-block-devices
+++ b/scripts/mount-block-devices
@@ -34,7 +34,7 @@ do
     cat /etc/fstab | grep -v "${drive}" > /tmp/fstab.tmp
     # Re-add our config to fstab
     #   Note: There are tabs on purpose in here - be careful
-    echo "${drive}  ${EC2_DRIVES[$drive]} auto  defaults,nobootwait,comment=cloudconfig 0 2" >> /tmp/fstab.tmp
+    echo "${drive}  ${EC2_DRIVES[$drive]} auto  defaults,comment=cloudconfig 0 2" >> /tmp/fstab.tmp
     # Move the tmp file into place
     mv /tmp/fstab.tmp /etc/fstab
   fi

--- a/scripts/starphleet-install
+++ b/scripts/starphleet-install
@@ -51,7 +51,7 @@ do
     cat /etc/fstab | grep -v "${drive}" > /tmp/fstab.tmp
     # Re-add our config to fstab
     #   Note: There are tabs on purpose in here - be careful
-    echo "${drive}	${EC2_DRIVES[$drive]}	auto	defaults,nobootwait,comment=cloudconfig	0	2" >> /tmp/fstab.tmp
+    echo "${drive}	${EC2_DRIVES[$drive]}	auto	defaults,comment=cloudconfig	0	2" >> /tmp/fstab.tmp
     # Move the tmp file into place
     mv /tmp/fstab.tmp /etc/fstab
   fi


### PR DESCRIPTION
Nobootwait was removed as an option in Ubuntu 16. This causes the drives
to fail to mount. Tested the change on a devDB install using Ubuntu 16
successfully.

Issue: https://askubuntu.com/questions/786928/ubuntu-16-04-fstab-fails-with-nobootwait