### PR TITLE
Re-source orders after container is decompressed

### DIFF
--- a/scripts/starphleet-containermake
+++ b/scripts/starphleet-containermake
@@ -256,6 +256,11 @@ EOF
     starphleet-lxc-wait ${CONTAINER_NAME} RUNNING
     lxc-attach --name ${CONTAINER_NAME} ${LXC_OPT_FOR_STDOUT} -- bash starphleet-wait-network
   fi
+  
+  # Since all containers are built in one region at the moment, the region environment variables are stuck.
+  # Re-sourcing orers so correct variables are set when running in a new region.
+  info "Re-sourcing orders for accurate environment variables"
+  lxc-attach --name ${CONTAINER_NAME} ${LXC_OPT_FOR_STDOUT} -- bash -c starphleet-source-orders
 
   info "Configuring Network For Container"
   bridge_ip

--- a/scripts/starphleet-source-orders
+++ b/scripts/starphleet-source-orders
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+### Usage:
+###    starphleet-source-orders
+###
+### Used to source the orders in a container
+
+# Why is this line needed?
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Source the tools that allow you to run_orders
+source `which tools`
+
+# Apply orders
+run_orders "${HEADQUARTERS_LOCAL}/${ORDERS_NAME}/orders"


### PR DESCRIPTION
Why: containers are currently built in one region (ie. Virginia), however they may be deployed in another region (Singapore) with different environment specific variables. Re-source the local orders file when the container is decompressed to reflect accurate variables.