### PR TITLE
Add region argument to aws s3 call to download secrets binary.

### DIFF
--- a/scripts/starphleet-containerize
+++ b/scripts/starphleet-containerize
@@ -54,7 +54,7 @@ EOF
 #Downloads the latest secrets binary
 cat << 'EOF' >> ${CONTAINER_BUILD_SCRIPT}
 trace Downloading latest secrets binary
-sudo aws s3 cp s3://glg-deployment-packages/secrets /usr/bin/secrets
+sudo aws s3 cp s3://glg-deployment-packages/secrets /usr/bin/secrets --region us-east-1
 sudo chmod +x /usr/bin/secrets
 EOF
 


### PR DESCRIPTION
The region arg is as much a part of the path as the bucket name.