### PR TITLE
Guarantee JSON functionality along with secrets

### DIFF
--- a/scripts/starphleet-containerize
+++ b/scripts/starphleet-containerize
@@ -51,6 +51,13 @@ echo "ssh -F /tmp/gitsshconfig \$@" > /tmp/gitssh
 chmod +x /tmp/gitssh
 EOF
 
+#Downloads the latest secrets binary
+cat << 'EOF' >> ${CONTAINER_BUILD_SCRIPT}
+trace Downloading latest secrets binary
+sudo aws s3 cp s3://glg-deployment-packages/secrets /usr/bin/secrets
+sudo chmod +x /usr/bin/secrets
+EOF
+
 #now -- this is escaped, lots of variables included from this script
 cat << EOF >> ${CONTAINER_BUILD_SCRIPT}
 

--- a/scripts/starphleet-containerize
+++ b/scripts/starphleet-containerize
@@ -56,8 +56,19 @@ cat << 'EOF' >> ${CONTAINER_BUILD_SCRIPT}
 trace Downloading latest secrets binary
 sudo aws s3 cp s3://glg-deployment-packages/secrets /usr/bin/secrets --region us-east-1
 sudo chmod +x /usr/bin/secrets
-trace Installing jq
-sudo apt-get install -y jq
+
+# Usage - fromJson "somejsonstring" "somekey"
+function fromJson() {
+    python -c \
+"import json
+import sys
+json_string, json_key = sys.argv[1:]
+try:
+    print json.loads(json_string)[json_key]
+except Exception:
+    print >> sys.stderr, \"This isn't json!\"" \
+    "${1}" "${2}"
+}
 EOF
 
 #now -- this is escaped, lots of variables included from this script

--- a/scripts/starphleet-containerize
+++ b/scripts/starphleet-containerize
@@ -56,6 +56,8 @@ cat << 'EOF' >> ${CONTAINER_BUILD_SCRIPT}
 trace Downloading latest secrets binary
 sudo aws s3 cp s3://glg-deployment-packages/secrets /usr/bin/secrets --region us-east-1
 sudo chmod +x /usr/bin/secrets
+trace Installing jq
+sudo apt-get install -y jq
 EOF
 
 #now -- this is escaped, lots of variables included from this script


### PR DESCRIPTION
Ensuring that jq is in every container will give devs more flexibility when dealing with json secrets, and provides a universally available solution (as opposed to `fromJson` which is starphleet specific). This way they can learn one workflow for secrets, whether working locally, dev ship, production, jobs, etc.