### PR TITLE
get local ip address in a universal way

### DIFF
--- a/overlay/etc/init/starphleet.pre-start
+++ b/overlay/etc/init/starphleet.pre-start
@@ -5,7 +5,8 @@ set +e
 
 # Set the local IP
 mkdir -p /etc/starphleet.d
-LOCAL_IP=$(ifconfig eth0 | grep "inet addr" | cut -f2 -d":" | cut -f1 -d" ")
+IFACE=$(netstat -rn | egrep '^0.0' | awk '{print $8}')
+LOCAL_IP=$(ifconfig "${IFACE}" | grep "inet " | cut -f2 -d":" | cut -f1 -d" ")
 echo INTERNAL_HOST=\"${LOCAL_IP}\" > /etc/starphleet.d/internal_host
 
 source `which tools`


### PR DESCRIPTION
Tested on both 14.04 (with an eth0 adapter) and 16.04 (with an ens5 adapter). Both work.

16.04:
![image](https://user-images.githubusercontent.com/6332286/56526318-253fbd00-651a-11e9-8420-07c1ef18eae3.png)

14:04:
![image](https://user-images.githubusercontent.com/6332286/56526387-338dd900-651a-11e9-83ef-02f6fda2fd15.png)
