### PR TITLE
Changes to provide auth0 support

### DIFF
--- a/overlay/var/starphleet/nginx/lua/jwt.lua
+++ b/overlay/var/starphleet/nginx/lua/jwt.lua
@@ -238,7 +238,7 @@ end
 -- If auth is required and the acr claim is missing or not equal to 1 (authed)
 -- then set header
 ------------------------------------------------------------------------------
-if token and jwt_auth_required and (not token.payload.acr or token.payload.acr ~= 1) then
+if token and jwt_auth_required and (not token.payload.acr) then
   ngx.req.set_header('X-Starphleet-Auth-Required', jwt_auth_required)
   token = nil
 end

--- a/overlay/var/starphleet/nginx/lua/jwt.lua
+++ b/overlay/var/starphleet/nginx/lua/jwt.lua
@@ -235,17 +235,17 @@ end
 
 ------------------------------------------------------------------------------
 -- acr claim and auth required:
--- If auth is required and the acr claim is missing or not equal to 1 (authed)
--- then set header
+-- if auth requred and no token set the header.
+-- If auth is required and the acr claim is missing set header.
 ------------------------------------------------------------------------------
-if token and jwt_auth_required and (not token.payload.acr) then
-  ngx.req.set_header('X-Starphleet-Auth-Required', jwt_auth_required)
-  token = nil
+if jwt_auth_required then
+  if not token then
+    ngx.req.set_header('X-Starphleet-Auth-Required', "true")
+  elseif token and (not token.payload.acr) then
+    ngx.req.set_header('X-Starphleet-Auth-Required', jwt_auth_required)
+    token = nil
+  end
 end
-
-if not token and jwt_auth_required then
-  ngx.req.set_header('X-Starphleet-Auth-Required', "true")
-end  
 
 ------------------------------------------------------------------------------
 -- Access Flags:

--- a/overlay/var/starphleet/nginx/lua/jwt.lua
+++ b/overlay/var/starphleet/nginx/lua/jwt.lua
@@ -239,10 +239,8 @@ end
 -- If auth is required and the acr claim is missing set header.
 ------------------------------------------------------------------------------
 if jwt_auth_required then
-  if not token then
-    ngx.req.set_header('X-Starphleet-Auth-Required', jwt_auth_required)
-  elseif token and (not token.payload.acr) then
-    ngx.req.set_header('X-Starphleet-Auth-Required', jwt_auth_required)
+  ngx.req.set_header('X-Starphleet-Auth-Required', jwt_auth_required)
+  if token and token.payload and not token.payload.acr then
     token = nil
   end
 end
@@ -261,7 +259,7 @@ if token
   local _accessDeniedFlags = token.payload.af .. "," .. jwt_access_flags
   ngx.req.set_header('X-Starphleet-Access-Denied', _accessDeniedFlags)
   token = nil
-end  
+end
 
 ------------------------------------------------------------------------------
 -- If the above process results in a valid token then we set the cookie

--- a/overlay/var/starphleet/nginx/lua/jwt.lua
+++ b/overlay/var/starphleet/nginx/lua/jwt.lua
@@ -238,12 +238,12 @@ end
 -- If auth is required and the acr claim is missing or not equal to 1 (authed)
 -- then set header
 ------------------------------------------------------------------------------
-if token and jwt_auth_required and (!token.payload.acr or token.payload.acr !== 1) then
+if token and jwt_auth_required and (not token.payload.acr or token.payload.acr ~= 1) then
   ngx.req.set_header('X-Starphleet-Auth-Required', jwt_auth_required)
   token = nil
 end
 
-if !token and jwt_auth_required then
+if not token and jwt_auth_required then
   ngx.req.set_header('X-Starphleet-Auth-Required', "true")
 end  
 

--- a/overlay/var/starphleet/nginx/lua/jwt.lua
+++ b/overlay/var/starphleet/nginx/lua/jwt.lua
@@ -234,6 +234,20 @@ elseif _isValidToken(verified_cookie_token) then
 end
 
 ------------------------------------------------------------------------------
+-- acr claim and auth required:
+-- If auth is required and the acr claim is missing or not equal to 1 (authed)
+-- then set header
+------------------------------------------------------------------------------
+if token and jwt_auth_required and (!token.payload.acr or token.payload.acr !== 1) then
+  ngx.req.set_header('X-Starphleet-Auth-Required', jwt_auth_required)
+  token = nil
+end
+
+if !token and jwt_auth_required then
+  ngx.req.set_header('X-Starphleet-Auth-Required', "true")
+end  
+
+------------------------------------------------------------------------------
 -- Access Flags:
 -- If the valid token contains 'af' (access flags) we will limit
 -- the response at a service level based on these flags.
@@ -246,16 +260,6 @@ if token
   and bit.band(token.payload.af, jwt_access_flags) == 0 then
   local _accessDeniedFlags = token.payload.af .. "," .. jwt_access_flags
   ngx.req.set_header('X-Starphleet-Access-Denied', _accessDeniedFlags)
-  token = nil
-end
-
-------------------------------------------------------------------------------
--- acr claim and auth required:
--- If auth is required and the acr claim is missing or not equal to 1 (authed)
--- then set header
-------------------------------------------------------------------------------
-if token and jwt_auth_required and (!token.payload.acr or token.payload.acr !== 1) then
-  ngx.req.set_header('X-Starphleet-Auth-Required', jwt_auth_required)
   token = nil
 end  
 

--- a/overlay/var/starphleet/nginx/lua/jwt.lua
+++ b/overlay/var/starphleet/nginx/lua/jwt.lua
@@ -13,6 +13,7 @@ local jwt_revocation_dir = ngx.var.jwt_revocation_dir
 local jwt_max_token_age_in_seconds = tonumber(ngx.var.jwt_max_token_age_in_seconds)
 local jwt_expiration_in_seconds = tonumber(ngx.var.jwt_expiration_in_seconds)
 local headers = ngx.req.get_headers()
+local jwt_auth_required = ngx.var.jwt_auth_required
 
 -- *****************************************************************************
 -- * Guards
@@ -247,6 +248,16 @@ if token
   ngx.req.set_header('X-Starphleet-Access-Denied', _accessDeniedFlags)
   token = nil
 end
+
+------------------------------------------------------------------------------
+-- acr claim and auth required:
+-- If auth is required and the acr claim is missing or not equal to 1 (authed)
+-- then set header
+------------------------------------------------------------------------------
+if token and jwt_auth_required and (!token.payload.acr or token.payload.acr !== 1) then
+  ngx.req.set_header('X-Starphleet-Auth-Required', jwt_auth_required)
+  token = nil
+end  
 
 ------------------------------------------------------------------------------
 -- If the above process results in a valid token then we set the cookie

--- a/overlay/var/starphleet/nginx/lua/jwt.lua
+++ b/overlay/var/starphleet/nginx/lua/jwt.lua
@@ -240,7 +240,7 @@ end
 ------------------------------------------------------------------------------
 if jwt_auth_required then
   if not token then
-    ngx.req.set_header('X-Starphleet-Auth-Required', "true")
+    ngx.req.set_header('X-Starphleet-Auth-Required', jwt_auth_required)
   elseif token and (not token.payload.acr) then
     ngx.req.set_header('X-Starphleet-Auth-Required', jwt_auth_required)
     token = nil

--- a/scripts/starphleet-publish
+++ b/scripts/starphleet-publish
@@ -108,6 +108,7 @@ cat << EOF >> "${MOUNT_CONF}"
   set \$jwt_max_token_age_in_seconds ${JWT_MAX_TOKEN_AGE_IN_SECONDS};
   set \$jwt_expiration_in_seconds ${JWT_EXPIRATION_IN_SECONDS};
   set \$authentic_token "${STARPHLEET_AUTHENTIC_TOKEN}";
+  set \$jwt_auth_required "${JWT_AUTH_REQUIRED}";
   access_by_lua_file /var/starphleet/nginx/lua/jwt.lua;
 EOF
 fi


### PR DESCRIPTION
The starphleet-publish was modified to add another variable called jwt_auth_required that will allow support of auth0. This variable is read in the jwt.lua file and there are 2 scenarios:

1. User does not have a token and auth is required so set header.
2. User does have a valid token and the new acr jwt claim is not set. 