### PR TITLE
Patch runner to source start

### DIFF
--- a/scripts/runner
+++ b/scripts/runner
@@ -10,6 +10,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source ${DIR}/tools
 
 container_environment ${app_root} ${orders}
+[ -f /home/ubuntu/start ] && source /home/ubuntu/start
 
 cp "${scriptsource}" "${tmpscriptpath}"
 chmod +x "${tmpscriptpath}"

--- a/scripts/runner
+++ b/scripts/runner
@@ -10,7 +10,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source ${DIR}/tools
 
 container_environment ${app_root} ${orders}
-[ -f /home/ubuntu/start ] && source /home/ubuntu/start
+[ -f "/home/ubuntu/start" ] && source "/home/ubuntu/start"
 
 cp "${scriptsource}" "${tmpscriptpath}"
 chmod +x "${tmpscriptpath}"


### PR DESCRIPTION
- It turns out source and container_environment do not fully load the
environment as would normally be available to an application.  In the
instance where it's appropriate, and a start file exists, we should also
source the start file